### PR TITLE
Issue 5

### DIFF
--- a/README.md
+++ b/README.md
@@ -88,6 +88,8 @@ There are three additional configuration attributes for this config builder:
     (vaultName="MyVaultName" |
      uri="https://MyVaultName.vault.azure.net")
     [connectionString="connection string"]
+	[version="secrets version"]
+	[preloadSecretNames="true"]
     type="Microsoft.Configuration.ConfigurationBuilders.AzureKeyVaultConfigBuilder, Microsoft.Configuration.ConfigurationBuilders.Azure" />
 ```
 If your secrets are kept in Azure Key Vault, then this config builder is for you. There are three additional attributes for this config builder. The `vaultName` is
@@ -97,6 +99,10 @@ up connection information from the execution environment if possible, but you ca
   * `vaultName` - This is a required attribute. It specifies the name of the vault in your Azure subscription from which to read key/value pairs.
   * `connectionString` - A connection string usable by [AzureServiceTokenProvider](https://docs.microsoft.com/en-us/azure/key-vault/service-to-service-authentication#connection-string-support)
   * `uri` - Connect to other Key Vault providers with this attribute. If not specified, Azure is the assumed Vault provider. If the uri _is_specified, then `vaultName` is no longer a required parameter.
+  * `version` - Azure Key Vault provides a versioning feature for secrets. If this is specified, the builder will only retrieve secrets matching this version.
+  * `preloadSecretNames` - By default, this builder will query __all__ the key names in the key vault when it is initialized. If this is a concern, set
+  this attribute to 'false', and secrets will be retrieved one at a time. This could also be useful if the vault allows "Get" access but not
+  "List" access. (NOTE: Disabling preload is incompatible with Greedy mode.)
 
 ### SimpleJsonConfigBuilder
 ```xml

--- a/src/Azure/AzureKeyVaultConfigBuilder.cs
+++ b/src/Azure/AzureKeyVaultConfigBuilder.cs
@@ -38,7 +38,7 @@ namespace Microsoft.Configuration.ConfigurationBuilders
             if (!Boolean.TryParse(config?[preloadTag], out _preload))
                 _preload = true;
             if (!_preload && Mode == KeyValueMode.Greedy)
-                throw new ArgumentException($"AzureKeyVaultConfigBuilder {name}: '{preloadTag}'='false' is not compatible with {KeyValueMode.Greedy} mode.");
+                throw new ArgumentException($"'{preloadTag}'='false' is not compatible with {KeyValueMode.Greedy} mode.");
 
             _uri = config?[uriTag];
             _vaultName = config?[vaultNameTag];

--- a/src/Azure/AzureKeyVaultConfigBuilder.cs
+++ b/src/Azure/AzureKeyVaultConfigBuilder.cs
@@ -19,10 +19,14 @@ namespace Microsoft.Configuration.ConfigurationBuilders
         public const string vaultNameTag = "vaultName";
         public const string connectionStringTag = "connectionString";
         public const string uriTag = "uri";
+        public const string versionTag = "version";
+        public const string preloadTag = "preloadSecretNames";
 
         private string _vaultName;
         private string _connectionString;
         private string _uri;
+        private string _version;
+        private bool _preload;
 
         private KeyVaultClient _kvClient;
         private List<string> _allKeys;
@@ -31,8 +35,14 @@ namespace Microsoft.Configuration.ConfigurationBuilders
         {
             base.Initialize(name, config);
 
+            if (!Boolean.TryParse(config?[preloadTag], out _preload))
+                _preload = true;
+            if (!_preload && Mode == KeyValueMode.Greedy)
+                throw new ArgumentException($"AzureKeyVaultConfigBuilder {name}: '{preloadTag}'='false' is not compatible with {KeyValueMode.Greedy} mode.");
+
             _uri = config?[uriTag];
             _vaultName = config?[vaultNameTag];
+            _version = config?[versionTag];
 
             if (String.IsNullOrWhiteSpace(_uri))
             {
@@ -50,7 +60,9 @@ namespace Microsoft.Configuration.ConfigurationBuilders
             AzureServiceTokenProvider tokenProvider = new AzureServiceTokenProvider(_connectionString);
             _kvClient = new KeyVaultClient(new KeyVaultClient.AuthenticationCallback(tokenProvider.KeyVaultTokenCallback));
 
-            _allKeys = GetAllKeys();
+            if (_preload) {
+                _allKeys = GetAllKeys();
+            }
         }
 
         public override string GetValue(string key)
@@ -80,8 +92,14 @@ namespace Microsoft.Configuration.ConfigurationBuilders
 
         private async Task<string> GetValueAsync(string key)
         {
-            if (_allKeys.Contains(key, StringComparer.OrdinalIgnoreCase))
+            if (!_preload || _allKeys.Contains(key, StringComparer.OrdinalIgnoreCase))
             {
+                if (!String.IsNullOrWhiteSpace(_version))
+                {
+                    var versionedSecret = await _kvClient.GetSecretAsync(_uri, key, _version);
+                    return versionedSecret?.Value;
+                }
+
                 var secret = await _kvClient.GetSecretAsync(_uri, key);
                 return secret?.Value;
             }
@@ -91,13 +109,22 @@ namespace Microsoft.Configuration.ConfigurationBuilders
 
         private List<string> GetAllKeys()
         {
-            var allSecrets = Task.Run(async () => { return await _kvClient.GetSecretsAsync(_uri); }).Result;
-
-            List<Task> tasks = new List<Task>();
             List<string> keys = new List<string>(); // KeyVault keys are case-insensitive. There won't be case-duplicates. List<> should be fine.
 
+            // Get first page of secret keys
+            var allSecrets = Task.Run(async () => { return await _kvClient.GetSecretsAsync(_uri); }).Result;
             foreach (var secretItem in allSecrets)
                 keys.Add(secretItem.Identifier.Name);
+
+            // If there more more pages, get those too
+            string nextPage = allSecrets.NextPageLink;
+            while (!String.IsNullOrWhiteSpace(nextPage))
+            {
+                var moreSecrets = Task.Run(async () => { return await _kvClient.GetSecretsNextAsync(nextPage); }).Result;
+                foreach (var secretItem in moreSecrets)
+                    keys.Add(secretItem.Identifier.Name);
+                nextPage = moreSecrets.NextPageLink;
+            }
 
             return keys;
         }


### PR DESCRIPTION
Do proper handling of paged data when querying Azure Key Vault for all secrets in vaults that contain a large number of secrets. Also add an option to avoid preloading _all_ secrets in Strict/Expand modes and retrieve only the ones needed one-by-one as they are used.