### PR TITLE
Use the correct uriTag identifier

### DIFF
--- a/README.md
+++ b/README.md
@@ -99,7 +99,7 @@ There are three additional configuration attributes for this config builder:
 <add name="AzureKeyVault"
     [mode|prefix|stripPrefix|tokenPattern]
     (vaultName="MyVaultName" |
-     uri="https://MyVaultName.vault.azure.net")
+     vaultUri="https://MyVaultName.vault.azure.net")
     [connectionString="connection string"]
     [version="secrets version"]
     [preloadSecretNames="true"]
@@ -111,7 +111,7 @@ environment that works magically with `Microsoft.Azure.Services.AppAuthenticatio
 up connection information from the execution environment if possible, but you can override that feature by providing a connection string instead.
   * `vaultName` - This is a required attribute. It specifies the name of the vault in your Azure subscription from which to read key/value pairs.
   * `connectionString` - A connection string usable by [AzureServiceTokenProvider](https://docs.microsoft.com/en-us/azure/key-vault/service-to-service-authentication#connection-string-support)
-  * `uri` - Connect to other Key Vault providers with this attribute. If not specified, Azure is the assumed Vault provider. If the uri _is_specified, then `vaultName` is no longer a required parameter.
+  * `vaultUri` - Connect to other Key Vault providers with this attribute. If not specified, Azure is the assumed Vault provider. If the uri _is_specified, then `vaultName` is no longer a required parameter.
   * `version` - Azure Key Vault provides a versioning feature for secrets. If this is specified, the builder will only retrieve secrets matching this version.
   * `preloadSecretNames` - By default, this builder will query __all__ the key names in the key vault when it is initialized. If this is a concern, set
   this attribute to 'false', and secrets will be retrieved one at a time. This could also be useful if the vault allows "Get" access but not

--- a/src/Azure/AzureKeyVaultConfigBuilder.cs
+++ b/src/Azure/AzureKeyVaultConfigBuilder.cs
@@ -23,7 +23,7 @@ namespace Microsoft.Configuration.ConfigurationBuilders
         #pragma warning disable CS1591 // No xml comments for tag literals.
         public const string vaultNameTag = "vaultName";
         public const string connectionStringTag = "connectionString";
-        public const string uriTag = "uri";
+        public const string uriTag = "vaultUri";
         public const string versionTag = "version";
         public const string preloadTag = "preloadSecretNames";
         #pragma warning restore CS1591 // No xml comments for tag literals.


### PR DESCRIPTION
Visual Studio connected services add the config with the uriTag as 'vaultUri' instead of 'uri'.

Below is what Visual Studio adds by default when adding Key Vault via Connected Service
``` xml
<add
      name="AzureKeyVault"
      vaultName="vaultName"
      type="Microsoft.Configuration.ConfigurationBuilders.AzureKeyVaultConfigBuilder, Microsoft.Configuration.ConfigurationBuilders.Azure, Version=1.0.0.0, Culture=neutral"
      vaultUri="https://vaultName.vault.azure.net" />
```
Updating the constant value to match what is set by VisualStudio.