### PR TITLE
Handle BadParameter error code from KeyVault

### DIFF
--- a/src/Azure/AzureKeyVaultConfigBuilder.cs
+++ b/src/Azure/AzureKeyVaultConfigBuilder.cs
@@ -130,7 +130,7 @@ namespace Microsoft.Configuration.ConfigurationBuilders
                     return secret?.Value;
                 } catch (KeyVaultErrorException kve) {
                     // Simply return null if the secret wasn't found
-                    if (kve.Body.Error.Code == "SecretNotFound")
+                    if (kve.Body.Error.Code == "SecretNotFound" || kve.Body.Error.Code == "BadParameter")
                         return null;
 
                     // If there was a permission issue or some other error, let the exception bubble


### PR DESCRIPTION
When secret names do not match the key vault object name constraint (0-9, a-z, A-Z, and -.) it throws a _BadParameter _ error code. This might a key that is defined in the configuration file which is not intended to be pulled in from KeyVault config while. When preload is set to false all keys are iterated to looks for a match in which case such invalid requests can be made.
#22 