### PR TITLE
Update Microsoft.Configuration.ConfigurationBuilders.Environment.nuspec

### DIFF
--- a/src/packages/ConfigurationBuilders.Environment.nupkg/Microsoft.Configuration.ConfigurationBuilders.Environment.nuspec
+++ b/src/packages/ConfigurationBuilders.Environment.nupkg/Microsoft.Configuration.ConfigurationBuilders.Environment.nuspec
@@ -7,8 +7,8 @@
     <owners>Microsoft</owners>
     <copyright>&#169; Microsoft Corporation. All rights reserved.</copyright>
     <title>Microsoft Configuration Builders - Environment</title>
-    <description>A simple key/value Configuration Builder for the .Net Desktop Framework that draws from environment variables.</description>
-    <summary>A simple key/value Configuration Builder for the .Net Desktop Framework that draws from environment variables.</summary>
+    <description>A key/value Configuration Builder for the .Net Framework that draws from environment variables.</description>
+    <summary>A simple key/value Configuration Builder for the .Net Framework that draws from environment variables.</summary>
     <language>en-US</language>
     <projectUrl>https://github.com/aspnet/MicrosoftConfigurationBuilders</projectUrl>
     <iconUrl>http://go.microsoft.com/fwlink/?LinkID=288859</iconUrl>


### PR DESCRIPTION
I could replace `simple` with `basic` (simple is banned by the MS style guide), but basic is not necessary.

Once we agree on changes, I'll fix all the others in one PR.

**.Net Desktop Framework** is not approved terminology. 