### PR TITLE
Adds WorkerRoleConfigurationBuilder

### DIFF
--- a/MicrosoftConfigurationBuilders.sln
+++ b/MicrosoftConfigurationBuilders.sln
@@ -1,7 +1,7 @@
 ﻿
 Microsoft Visual Studio Solution File, Format Version 12.00
-# Visual Studio 15
-VisualStudioVersion = 15.0.27130.2036
+# Visual Studio Version 16
+VisualStudioVersion = 16.0.29020.237
 MinimumVisualStudioVersion = 10.0.40219.1
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Azure", "src\Azure\Azure.csproj", "{345C5437-4990-45DC-BE34-6E37AA05D8D2}"
 	ProjectSection(ProjectDependencies) = postProject
@@ -60,6 +60,8 @@ Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "SampleWebApp", "samples\Sam
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "AzureAppConfig", "src\AzureAppConfig\AzureAppConfig.csproj", "{3F1BB24A-355F-49E7-B396-6AA2EB5DDA0E}"
 EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "WorkerRoleServiceConfiguration", "WorkerRoleServiceConfiguration\WorkerRoleServiceConfiguration.csproj", "{F5D796AA-D698-43B5-9F78-5BEF68BE2C8E}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -106,6 +108,10 @@ Global
 		{3F1BB24A-355F-49E7-B396-6AA2EB5DDA0E}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{3F1BB24A-355F-49E7-B396-6AA2EB5DDA0E}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{3F1BB24A-355F-49E7-B396-6AA2EB5DDA0E}.Release|Any CPU.Build.0 = Release|Any CPU
+		{F5D796AA-D698-43B5-9F78-5BEF68BE2C8E}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{F5D796AA-D698-43B5-9F78-5BEF68BE2C8E}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{F5D796AA-D698-43B5-9F78-5BEF68BE2C8E}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{F5D796AA-D698-43B5-9F78-5BEF68BE2C8E}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE

--- a/WorkerRoleServiceConfiguration/Properties/AssemblyInfo.cs
+++ b/WorkerRoleServiceConfiguration/Properties/AssemblyInfo.cs
@@ -1,0 +1,36 @@
+﻿using System.Reflection;
+using System.Runtime.CompilerServices;
+using System.Runtime.InteropServices;
+
+// General Information about an assembly is controlled through the following
+// set of attributes. Change these attribute values to modify the information
+// associated with an assembly.
+[assembly: AssemblyTitle("WorkerRoleServiceConfiguration")]
+[assembly: AssemblyDescription("")]
+[assembly: AssemblyConfiguration("")]
+[assembly: AssemblyCompany("")]
+[assembly: AssemblyProduct("WorkerRoleServiceConfiguration")]
+[assembly: AssemblyCopyright("Copyright ©  2019")]
+[assembly: AssemblyTrademark("")]
+[assembly: AssemblyCulture("")]
+
+// Setting ComVisible to false makes the types in this assembly not visible
+// to COM components.  If you need to access a type in this assembly from
+// COM, set the ComVisible attribute to true on that type.
+[assembly: ComVisible(false)]
+
+// The following GUID is for the ID of the typelib if this project is exposed to COM
+[assembly: Guid("f5d796aa-d698-43b5-9f78-5bef68be2c8e")]
+
+// Version information for an assembly consists of the following four values:
+//
+//      Major Version
+//      Minor Version
+//      Build Number
+//      Revision
+//
+// You can specify all the values or you can default the Build and Revision Numbers
+// by using the '*' as shown below:
+// [assembly: AssemblyVersion("1.0.*")]
+[assembly: AssemblyVersion("1.0.0.0")]
+[assembly: AssemblyFileVersion("1.0.0.0")]

--- a/WorkerRoleServiceConfiguration/WorkerRoleConfigurationBuilder.cs
+++ b/WorkerRoleServiceConfiguration/WorkerRoleConfigurationBuilder.cs
@@ -1,0 +1,76 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Configuration;
+using Microsoft.WindowsAzure.ServiceRuntime;
+
+namespace Microsoft.Configuration.ConfigurationBuilders
+{
+    public class WorkerRoleConfigurationBuilder : KeyValueConfigBuilder
+    {
+        public override string GetValue(string key)
+        {
+            return null;
+        }
+
+        public override ICollection<KeyValuePair<string, string>> GetAllValues(string prefix)
+        {
+            return new Dictionary<string, string>();
+        }
+
+        public override ConfigurationSection ProcessConfigurationSection(ConfigurationSection configSection)
+        {
+            var res = base.ProcessConfigurationSection(configSection);
+
+            switch (configSection)
+            {
+                case ConnectionStringsSection connectionStringsSection:
+                    OverrideConnectionStringsWithCloud(connectionStringsSection);
+                    break;
+
+                case AppSettingsSection appSettingsSection:
+                    OverrideAppSettingsWithCloud(appSettingsSection);
+                    break;
+            }
+
+            return res;
+        }
+
+        private void OverrideConnectionStringsWithCloud(ConnectionStringsSection section)
+        {
+            foreach (ConnectionStringSettings conString in section.ConnectionStrings)
+            {
+                conString.ConnectionString = ResolveAppSettingValue(key: conString.Name, defaultValue: conString.ConnectionString);
+            }
+        }
+
+        private void OverrideAppSettingsWithCloud(AppSettingsSection section)
+        {
+            foreach (KeyValueConfigurationElement appSetting in section.Settings)
+            {
+                appSetting.Value = ResolveAppSettingValue(key: appSetting.Key, defaultValue: appSetting.Value);
+            }
+        }
+
+
+        private string ResolveAppSettingValue(string key, string defaultValue)
+        {
+            var hasSettingOnCloud = TryGetCloudAppSetting(key, out var cloudSettingValue);
+            return (hasSettingOnCloud) ? cloudSettingValue : defaultValue;
+        }
+
+        private bool TryGetCloudAppSetting(string key, out string settingValue)
+        {
+            try
+            {
+                settingValue = RoleEnvironment.GetConfigurationSettingValue(key);
+                return !string.IsNullOrWhiteSpace(settingValue);
+            }
+            catch (Exception)
+            {
+                // RoleEnvironment.GetConfigurationSettingValue throws if no value, so we want to trace this error and move on. 
+                settingValue = null;
+                return false;
+            }
+        }
+    }
+}

--- a/WorkerRoleServiceConfiguration/WorkerRoleServiceConfiguration.csproj
+++ b/WorkerRoleServiceConfiguration/WorkerRoleServiceConfiguration.csproj
@@ -1,0 +1,48 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="15.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <Import Project="$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props" Condition="Exists('$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props')" />
+  <PropertyGroup>
+    <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
+    <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
+    <ProjectGuid>{F5D796AA-D698-43B5-9F78-5BEF68BE2C8E}</ProjectGuid>
+    <OutputType>Library</OutputType>
+    <AppDesignerFolder>Properties</AppDesignerFolder>
+    <RootNamespace>WorkerRoleServiceConfiguration</RootNamespace>
+    <AssemblyName>WorkerRoleServiceConfiguration</AssemblyName>
+    <TargetFrameworkVersion>v4.7.1</TargetFrameworkVersion>
+    <FileAlignment>512</FileAlignment>
+    <Deterministic>true</Deterministic>
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
+    <DebugSymbols>true</DebugSymbols>
+    <DebugType>full</DebugType>
+    <Optimize>false</Optimize>
+    <OutputPath>bin\Debug\</OutputPath>
+    <DefineConstants>DEBUG;TRACE</DefineConstants>
+    <ErrorReport>prompt</ErrorReport>
+    <WarningLevel>4</WarningLevel>
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
+    <DebugType>pdbonly</DebugType>
+    <Optimize>true</Optimize>
+    <OutputPath>bin\Release\</OutputPath>
+    <DefineConstants>TRACE</DefineConstants>
+    <ErrorReport>prompt</ErrorReport>
+    <WarningLevel>4</WarningLevel>
+  </PropertyGroup>
+  <ItemGroup>
+    <Reference Include="System" />
+    <Reference Include="System.Configuration" />
+  </ItemGroup>
+  <ItemGroup>
+    <Compile Include="WorkerRoleConfigurationBuilder.cs" />
+    <Compile Include="Properties\AssemblyInfo.cs" />
+  </ItemGroup>
+  <ItemGroup>
+    <ProjectReference Include="..\src\Base\Base.csproj">
+      <Project>{f382fbf8-146d-4968-a199-90d37f9ef9a7}</Project>
+      <Name>Base</Name>
+    </ProjectReference>
+  </ItemGroup>
+  <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
+</Project>

--- a/WorkerRoleServiceConfiguration/packages.config
+++ b/WorkerRoleServiceConfiguration/packages.config
@@ -1,0 +1,5 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<packages>
+  <package id="Microsoft.Azure.ConfigurationManager" version="4.0.0" targetFramework="net472" />
+  <package id="Newtonsoft.Json" version="9.0.1" targetFramework="net472" />
+</packages>

--- a/test/Microsoft.Configuration.ConfigurationBuilders.Test/Test.csproj
+++ b/test/Microsoft.Configuration.ConfigurationBuilders.Test/Test.csproj
@@ -60,6 +60,7 @@
   </ItemGroup>
   <ItemGroup>
     <Compile Include="CommonBuilderTests.cs" />
+    <Compile Include="WorkerRoleConfigurationBuilderTests.cs" />
     <Compile Include="UserSecretsTests.cs" />
     <Compile Include="KeyPerFileTests.cs" />
     <Compile Include="SimpleJsonTests.cs" />

--- a/test/Microsoft.Configuration.ConfigurationBuilders.Test/WorkerRoleConfigurationBuilderTests.cs
+++ b/test/Microsoft.Configuration.ConfigurationBuilders.Test/WorkerRoleConfigurationBuilderTests.cs
@@ -1,0 +1,45 @@
+﻿using System;
+using Microsoft.Configuration.ConfigurationBuilders;
+using Xunit;
+
+
+namespace Test
+{
+    public class WorkerRoleConfigurationBuilderTests
+    {
+        public WorkerRoleConfigurationBuilderTests()
+        {
+            // Populate the filesystem with key/value pairs that are needed for common tests
+        }
+
+        // ======================================================================
+        //   KeyPerFile parameters
+        // ======================================================================
+        //    - See Parameters section of BaseTests for examples
+        // directoryPath
+        // keyDelimiter
+        // ignorePrefix
+        // optional
+
+
+        // ======================================================================
+        //   CommonBuilderTests
+        // ======================================================================
+        [Fact]
+        public void WorkerRoleConfigurationBuilder_GetValue()
+        {
+        }
+
+        [Fact]
+        public void WorkerRoleConfigurationBuilder_GetAllValues()
+        {
+        }
+
+        // ======================================================================
+        //   Errors
+        // ======================================================================
+        // Make sure various expected exceptions from KeyPerFile contain the name of the builder
+        // No file AND no ID specified
+        // File and/or ID specified, but can't be found and optional = false
+    }
+}


### PR DESCRIPTION
## Worker Role Configuration Builder
```
* Note: The following apply to both App.Config and Web.Config
```
### Background
Azure classic cloud services, and specifacally WorkerRoles are using `.cscfg` for service config schema. 
We want to be able to configure our applications via Azure Portal, while keeping all config declaration in the good old `App.Config`.

### WorkerRoleConfigurationBuilder
This class gives us the ability to override `App.Config` with configurations defined in the config schema (.cscfg) from Azure Portal. 
The classs `WorkerRoleConfigurationBuilder` extends `KeyValueConfigBuilder` from [`Microsoft.Configuration.ConfigurationBuilders.Base`](https://github.com/aspnet/MicrosoftConfigurationBuilders).

### Behaviour
- If a configuration is only defined in `App.Config` it will be used
- If a configuration is defined in both `App.Config` and `.cscfg`, the latter take precedence
- If a configuration is only defined in `.cscfg` nothing is overriden, it can be accessed with `RoleEnvironment.GetConfigurationSettingValue(key);`
