### PR TITLE
Fix spelling, 'configuraiton' -> 'configuration'

### DIFF
--- a/src/packages/ConfigurationBuilders.Azure.nupkg/README.txt
+++ b/src/packages/ConfigurationBuilders.Azure.nupkg/README.txt
@@ -4,7 +4,7 @@
 ##                                                                                                                    ##
 ########################################################################################################################
 
-WARNING: Double check config builder attributes in your configuraiton files. Some attributes may have been changed
+WARNING: Double check config builder attributes in your configuration files. Some attributes may have been changed
          when upgrading this package.
 
 If this is the first time you are installing this configuration builder into your

--- a/src/packages/ConfigurationBuilders.Environment.nupkg/README.txt
+++ b/src/packages/ConfigurationBuilders.Environment.nupkg/README.txt
@@ -4,7 +4,7 @@
 ##                                                                                                                    ##
 ########################################################################################################################
 
-WARNING: Double check config builder attributes in your configuraiton files. Some attributes may have been changed
+WARNING: Double check config builder attributes in your configuration files. Some attributes may have been changed
          when upgrading this package.
 
 If this is the first time you are installing this configuration builder into your

--- a/src/packages/ConfigurationBuilders.Json.nupkg/README.txt
+++ b/src/packages/ConfigurationBuilders.Json.nupkg/README.txt
@@ -4,7 +4,7 @@
 ##                                                                                                                    ##
 ########################################################################################################################
 
-WARNING: Double check config builder attributes in your configuraiton files. Some attributes may have been changed
+WARNING: Double check config builder attributes in your configuration files. Some attributes may have been changed
          when upgrading this package.
 
 If this is the first time you are installing this configuration builder into your

--- a/src/packages/ConfigurationBuilders.UserSecrets.nupkg/README.txt
+++ b/src/packages/ConfigurationBuilders.UserSecrets.nupkg/README.txt
@@ -4,7 +4,7 @@
 ##                                                                                                                    ##
 ########################################################################################################################
 
-WARNING: Double check config builder attributes in your configuraiton files. Some attributes may have been changed
+WARNING: Double check config builder attributes in your configuration files. Some attributes may have been changed
          when upgrading this package.
 
 If this is the first time you are installing this configuration builder into your


### PR DESCRIPTION
Typo in a couple of the README files.