### PR TITLE
Bring back connectionString for Azure App Configuration.

### DIFF
--- a/README.md
+++ b/README.md
@@ -210,7 +210,7 @@ and currently exposes the format of the file which, as mentioned above, should b
 ```xml
 <add name="AzureAppConfig"
     [mode|@prefix|@stripPrefix|tokenPattern|@escapeExpandedValues|@optional=false]
-    @endpoint="https://your-appconfig-store.azconfig.io"
+    (@endpoint="https://your-appconfig-store.azconfig.io" | @connectionString="Endpoint=https://your-appconfig-store.azconfig.io;Id=XXXXXXXXXX;Secret=XXXXXXXXXX")
     [@keyFilter="string"]
     [@labelFilter="label"]
     [@acceptDateTime="DateTimeOffset"]
@@ -218,12 +218,11 @@ and currently exposes the format of the file which, as mentioned above, should b
     type="Microsoft.Configuration.ConfigurationBuilders.AzureAppConfigurationBuilder, Microsoft.Configuration.ConfigurationBuilders.AzureAppConfig" />
 ```
 [AppConfiguration](https://docs.microsoft.com/en-us/azure/azure-app-configuration/overview) is a new offering from Azure, currently in preview. If you
-wish to use this new service for managing your configuration, then use this AzureAppConfigurationBuilder. `endpoint` is
-required, but all other attributes are optional.
-Previous iterations of this config builder allowed for a `connectionString` to connect to the
-App Configuration service. This method is no longer allowed, and this config builder now exclusively uses [DefaultAzureCredential](https://docs.microsoft.com/en-us/dotnet/api/azure.identity.defaultazurecredential)
-from the Azure.Identity package to handle credentials for connecting to the service.
+wish to use this new service for managing your configuration, then use this AzureAppConfigurationBuilder. Either `endpoint` or `connectionString` are
+required, but all other attributes are optional. If both `endpoint` and `connectionString` are used, then preference is given to the connection string.
   * `endpoint` - This specifies the AppConfiguration store to connect to.
+  * `connectionString` - This specifies the AppConfiguration store to connect to, along with the Id and Secret necessary to access the service. Be careful
+	not to expose any secrets in your code, repos, or App Configuration stores if you use this method for connecting.
   * `keyFilter` - Use this to select a set of configuration values matching a certain key pattern.
   * `labelFilter` - Only retrieve configuration values that match a certain label.
   * `acceptDateTime` - Instead of versioning ala Azure Key Vault, AppConfiguration uses timestamps. Use this attribute to go back in time

--- a/src/AzureAppConfig/AzureAppConfigurationBuilder.cs
+++ b/src/AzureAppConfig/AzureAppConfigurationBuilder.cs
@@ -28,7 +28,7 @@ namespace Microsoft.Configuration.ConfigurationBuilders
 
         #pragma warning disable CS1591 // No xml comments for tag literals.
         public const string endpointTag = "endpoint";
-        public const string connectionStringTag = "connectionString";   // obsolete
+        public const string connectionStringTag = "connectionString";
         public const string keyFilterTag = "keyFilter";
         public const string labelFilterTag = "labelFilter";
         public const string dateTimeFilterTag = "acceptDateTime";
@@ -36,6 +36,7 @@ namespace Microsoft.Configuration.ConfigurationBuilders
         #pragma warning restore CS1591 // No xml comments for tag literals.
 
         private Uri _endpoint;
+        private string _connectionString;
         private string _keyFilter;
         private string _labelFilter;
         private DateTimeOffset _dateTimeFilter;
@@ -82,33 +83,45 @@ namespace Microsoft.Configuration.ConfigurationBuilders
             if (_useKeyVault)
                 _kvClientCache = new ConcurrentDictionary<Uri, SecretClient>(EqualityComparer<Uri>.Default);
 
-            // Config Store Endpoint
-            string uri = UpdateConfigSettingWithAppSettings(endpointTag);
-            if (!String.IsNullOrWhiteSpace(uri))
+
+            // Always allow 'connectionString' to override black magic. But we expect this to be null most of the time.
+            _connectionString = UpdateConfigSettingWithAppSettings(connectionStringTag);
+            if (String.IsNullOrWhiteSpace(_connectionString))
             {
+                _connectionString = null;
+
+                // Use Endpoint instead
+                string uri = UpdateConfigSettingWithAppSettings(endpointTag);
+                if (!String.IsNullOrWhiteSpace(uri))
+                {
+                    try
+                    {
+                        _endpoint = new Uri(uri);
+                        _client = new ConfigurationClient(_endpoint, new DefaultAzureCredential());
+                    }
+                    catch (Exception ex)
+                    {
+                        if (!Optional)
+                            throw new ArgumentException($"Exception encountered while creating connection to Azure App Configuration store.", ex);
+                    }
+                }
+                else
+                {
+                    throw new ArgumentException($"An endpoint URI or connection string must be provided for connecting to Azure App Configuration service via the '{endpointTag}' or '{connectionStringTag}' attribute.");
+                }
+            }
+            else
+            {
+                // If we get here, then we should try to connect with a connection string.
                 try
                 {
-                    _endpoint = new Uri(uri);
-                    _client = new ConfigurationClient(_endpoint, new DefaultAzureCredential());
+                    _client = new ConfigurationClient(_connectionString);
                 }
                 catch (Exception ex)
                 {
                     if (!Optional)
                         throw new ArgumentException($"Exception encountered while creating connection to Azure App Configuration store.", ex);
                 }
-            }
-            else
-            {
-                throw new ArgumentException($"An endpoint URI must be provided for connecting to Azure App Configuration service via the '{endpointTag}' attribute.");
-            }
-
-            if (config[connectionStringTag] != null)
-            {
-                // A connection string was given. Connection strings are no longer supported. Azure.Identity is the preferred way to
-                // authenticate, and that library has various mechanisms other than a plain text connection string in config to obtain
-                // the necessary client credentials for connecting to Azure.
-                // Be noisy about this even if optional, as it is a fundamental misconfiguration going forward.
-                throw new ArgumentException("AzureAppConfigurationBuilder no longer supports connection strings.", connectionStringTag);
             }
 
             // At this point we've got all our ducks in a row and are ready to go. And we know that

--- a/src/packages/ConfigurationBuilders.AzureAppConfiguration.nupkg/tools/Net471/Install.ps1
+++ b/src/packages/ConfigurationBuilders.AzureAppConfiguration.nupkg/tools/Net471/Install.ps1
@@ -12,7 +12,8 @@ $keyVaultConfigBuilder = [BuilderDescription]@{
 	Version="$assemblyVersion$";
 	DefaultName="AzureAppConfig";
 	AllowedParameters=@( $keyValueCommonParameters +
-		[ParameterDescription]@{ Name="endpoint"; IsRequired=$true; DefaultValue="[Config_Store_Endpoint_Url]" },
+		[ParameterDescription]@{ Name="endpoint"; IsRequired=$false; DefaultValue="[Config_Store_Endpoint_Url]" },
+		[ParameterDescription]@{ Name="connectionString"; IsRequired=$false },
 		[ParameterDescription]@{ Name="keyFilter"; IsRequired=$false },
 		[ParameterDescription]@{ Name="labelFilter"; IsRequired=$false },
 		[ParameterDescription]@{ Name="acceptDateTime"; IsRequired=$false };


### PR DESCRIPTION
App Config team wants connection strings, and indicates that sensitive information should not be kept in App Config stores. Use Key Vault instead. Good practice would be to draw the connection string from AppSettings as well.