### PR TITLE
Remove a misleading error

### DIFF
--- a/src/Base/SectionHandlerSection.cs
+++ b/src/Base/SectionHandlerSection.cs
@@ -77,7 +77,7 @@ namespace Microsoft.Configuration.ConfigurationBuilders
                 }
             }
 
-            throw new Exception($"Error in Configuration: Cannot find ISectionHandler for '{configSection.SectionInformation.Name}' section.");
+            return null;
         }
     }
 }


### PR DESCRIPTION
Summary:
No need to throw an exception that isn't necessarily true, the caller checks for null.
Detail:
This is only called by one caller and the caller checks for null.  See 
KeyValueConfigBuilder.ProcessConfigurationSection.  No need to return an error.
Also, this the Exception that used to be here was misleading.  It said that the ISectionHandler couldn't be found, which wasn't always true.  The first 'if' in the 'for' loop checks for IsSubClassOf a desired type.  If this fails for all handlers, it is not that the ISectionHandler couldn't be found, but that it wasn't a desired type.  This occurs in Strict mode when not applied to a AppSettings or ConnectionString section.  (I tried a Strict mode configBuilder on an applicationSettings sub-section and the error wasn't correct because there was an ISectionHandler configured properly.)  Maybe this should fail earlier in this case.  Regardless, a misleading exception isn't necessary.