### PR TITLE
Add overload to GetCredential

### DIFF
--- a/src/Azure/AzureKeyVaultConfigBuilder.cs
+++ b/src/Azure/AzureKeyVaultConfigBuilder.cs
@@ -10,6 +10,7 @@ using System.Text.RegularExpressions;
 using System.Threading.Tasks;
 
 using Azure;
+using Azure.Core;
 using Azure.Identity;
 using Azure.Security.KeyVault.Secrets;
 
@@ -90,7 +91,7 @@ namespace Microsoft.Configuration.ConfigurationBuilders
             // Connect to KeyVault
             try
             {
-                _kvClient = new SecretClient(new Uri(_uri), new DefaultAzureCredential());
+                _kvClient = new SecretClient(new Uri(_uri), GetCredential());
             }
             catch (Exception)
             {
@@ -118,6 +119,12 @@ namespace Microsoft.Configuration.ConfigurationBuilders
             // to avoid potential deadlocks.
             return Task.Run(async () => { return await GetValueAsync(key); }).Result?.Value;
         }
+
+        /// <summary>
+        /// Gets a <see cref="TokenCredential"/> to authenticate with KeyVault. This defaults to <see cref="DefaultAzureCredential"/>.
+        /// </summary>
+        /// <returns>A token credential.</returns>
+        protected virtual TokenCredential GetCredential() => new DefaultAzureCredential();
 
         /// <summary>
         /// Retrieves all known key/value pairs from the Key Vault where the key begins with with <paramref name="prefix"/>.

--- a/src/AzureAppConfig/AzureAppConfigurationBuilder.cs
+++ b/src/AzureAppConfig/AzureAppConfigurationBuilder.cs
@@ -12,6 +12,7 @@ using System.Text.RegularExpressions;
 using System.Threading.Tasks;
 
 using Azure;
+using Azure.Core;
 using Azure.Data.AppConfiguration;
 using Azure.Identity;
 using Azure.Security.KeyVault.Secrets;
@@ -97,7 +98,7 @@ namespace Microsoft.Configuration.ConfigurationBuilders
                     try
                     {
                         _endpoint = new Uri(uri);
-                        _client = new ConfigurationClient(_endpoint, new DefaultAzureCredential());
+                        _client = new ConfigurationClient(_endpoint, GetCredential());
                     }
                     catch (Exception ex)
                     {
@@ -198,6 +199,12 @@ namespace Microsoft.Configuration.ConfigurationBuilders
             // again to avoid potential deadlocks.
             return Task.Run(async () => { return await GetAllValuesAsync(prefix); }).Result;
         }
+
+        /// <summary>
+        /// Gets a <see cref="TokenCredential"/> to authenticate with App Configuration. This defaults to <see cref="DefaultAzureCredential"/>.
+        /// </summary>
+        /// <returns>A token credential.</returns>
+        protected virtual TokenCredential GetCredential() => new DefaultAzureCredential();
 
         private async Task<string> GetValueAsync(string key)
         {


### PR DESCRIPTION
This adds overloads to the Azure-releated builders to get custom TokenCredential so we can customize what the TokenCredential looks like to enable scenarios that the default one may not.

Fixes #117 