### PR TITLE
Add enabled

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,8 +33,8 @@ Version 2 is here with some new features:
   * Updateable Keys - Builders can now massage key names before inserting into config. The [AzureKeyVaultConfigBuilder](#azurekeyvaultconfigbuilder) has been
 		updated to use this feature to allow embedding 'version' tags in key names instead of applying a single 'version' tag to the builder.  (Note: This is
 		seperate from, and performed *after* prefix stripping.)
-  * Base Optional Tag - The [optional](#optional) tag that some of the builders in this project employed in V1 has been moved into the base class and is now available
-		on all key/value config builders.
+  * **[[Obsolete]] This has been superceded by the [enabled](#enabled) tag.** (Base Optional Tag - The `optional` tag that some of the builders in
+        this project employed in V1 has been moved into the base class and is now available on all key/value config builders.)
   * Escaping Expanded Values - It is possible to xml-escape inserted values in `Expand` mode now using the new [escapeExpandedValues](#escapeexpandedvalues) attribute.
   * Section Handlers - This feature allows users to develop extensions that will apply key/value config to sections other than `appSettings` and `connectionStrings`
 		if desired. Read more about this feature in the [Section Handlers](#section-handlers) segment below.
@@ -84,9 +84,12 @@ A related setting that is common among all of these key/value builders is `strip
 strings... but now all the keys in AppSettings start with "AppSetting_". Maybe this is fine for code you wrote. Chances are that prefix is better off stripped from the
 key name before being inserted into AppSettings. `stripPrefix` is a boolean value, and accomplishes just that. It's default value is `false`.
 
-#### optional
-This setting is a boolean that specified whether to avoid throwing exceptions when the backing configuration source cannot be found or connected.
-The default default value is `true`, though some config builders (such as the Azure-based builders) will use a different default.
+#### enabled
+This is a setting that controls whether a config builder gets executed or not, and if it fails silently or not. Supported values are
+`enabled`, `disabled`, and `optional`. (As well as `true` and `false` as equivallents of enabled/disabled.) If 'enabled', then the builder will execute and throw
+exceptions when it fails. When 'disabled', builders will not execute. When set to 'optional', builders will execute but failures will be silent. This can be useful in
+cases like "User Secrets" where the backing secrets file is only likely to exist on a dev machine and not in a staging or test environment.
+The default value is `optional`, though some config builders (such as the KeyPerFile and Azure-based builders) will use `enabled`.
 
 #### escapeExpandedValues
 .Net configuration is XML-based in it's raw form. While these config builders work on `ConfigurationSection` objects in `Strict` and `Greedy` modes,
@@ -279,7 +282,7 @@ then the resulting xml that gets used to build the config object would look like
 ### EnvironmentConfigBuilder
 ```xml
 <add name="Environment"
-    [mode|@prefix|@stripPrefix|tokenPattern|@escapeExpandedValues|@optional=true]
+    [mode|@prefix|@stripPrefix|tokenPattern|@escapeExpandedValues|@enabled=optional]
     type="Microsoft.Configuration.ConfigurationBuilders.EnvironmentConfigBuilder, Microsoft.Configuration.ConfigurationBuilders.Environment" />
 ```
 This is the most basic of the config builders. It draws its values from Environment, and it does not have any additional configuration options.
@@ -292,7 +295,7 @@ This is the most basic of the config builders. It draws its values from Environm
 ### UserSecretsConfigBuilder
 ```xml
 <add name="UserSecrets"
-    [mode|@prefix|@stripPrefix|tokenPattern|@escapeExpandedValues|@optional=true]
+    [mode|@prefix|@stripPrefix|tokenPattern|@escapeExpandedValues|@enabled=optional]
     (@userSecretsId="12345678-90AB-CDEF-1234-567890" | @userSecretsFile="~\secrets.file")
     type="Microsoft.Configuration.ConfigurationBuilders.UserSecretsConfigBuilder, Microsoft.Configuration.ConfigurationBuilders.UserSecrets" />
 ```
@@ -328,7 +331,7 @@ and currently exposes the format of the file which, as mentioned above, should b
 ### AzureAppConfigurationBuilder
 ```xml
 <add name="AzureAppConfig"
-    [mode|@prefix|@stripPrefix|tokenPattern|@escapeExpandedValues|@optional=false]
+    [mode|@prefix|@stripPrefix|tokenPattern|@escapeExpandedValues|@enabled=enabled]
     (@endpoint="https://your-appconfig-store.azconfig.io" | @connectionString="Endpoint=https://your-appconfig-store.azconfig.io;Id=XXXXXXXXXX;Secret=XXXXXXXXXX")
     [@keyFilter="string"]
     [@labelFilter="label"]
@@ -358,7 +361,7 @@ required, but all other attributes are optional. If both `endpoint` and `connect
 ### AzureKeyVaultConfigBuilder
 ```xml
 <add name="AzureKeyVault"
-    [mode|@prefix|@stripPrefix|tokenPattern|@escapeExpandedValues|@optional=false]
+    [mode|@prefix|@stripPrefix|tokenPattern|@escapeExpandedValues|@enabled=enabled]
     (@vaultName="MyVaultName" | @uri="https://MyVaultName.vault.azure.net")
     [@version="secrets version"]
     [@preloadSecretNames="true"]
@@ -396,7 +399,7 @@ entries: `item1` and `item2`.
 ### KeyPerFileConfigBuilder
 ```xml
 <add name="KeyPerFile"
-    [mode|@prefix|@stripPrefix|tokenPattern|@escapeExpandedValues|@optional=false]
+    [mode|@prefix|@stripPrefix|tokenPattern|@escapeExpandedValues|@enabled=enabled]
     @directoryPath="PathToSourceDirectory"
     [@ignorePrefix="ignore."]
     [keyDelimiter=":"]
@@ -414,7 +417,7 @@ their orchestrated windows containers in this key-per-file manner.
 ### SimpleJsonConfigBuilder
 ```xml
 <add name="SimpleJson"
-    [mode|@prefix|@stripPrefix|tokenPattern|@escapeExpandedValues|@optional=true]
+    [mode|@prefix|@stripPrefix|tokenPattern|@escapeExpandedValues|@enabled=optional]
     @jsonFile="~\config.json"
     [@jsonMode="(Flat|Sectional)"]
     type="Microsoft.Configuration.ConfigurationBuilders.SimpleJsonConfigBuilder, Microsoft.Configuration.ConfigurationBuilders.Json" />

--- a/samples/SampleWebApp/App_Data/secrets.xml
+++ b/samples/SampleWebApp/App_Data/secrets.xml
@@ -16,5 +16,6 @@
     <secret name="SystemDrive" value="X:" />
     <secret name="JSONConfigFile" value="~/App_Data/settings.json" />
     <secret name="Boolean" value="true" />
+    <secret name="Optional" value="optional" />
   </secrets>
 </root>

--- a/samples/SampleWebApp/Web.config
+++ b/samples/SampleWebApp/Web.config
@@ -41,22 +41,22 @@
     <builders>
       <add name="Environment" type="Microsoft.Configuration.ConfigurationBuilders.EnvironmentConfigBuilder, Microsoft.Configuration.ConfigurationBuilders.Environment" />
       <add name="Secrets" userSecretsFile="~/App_Data/secrets.xml" mode="Greedy" type="Microsoft.Configuration.ConfigurationBuilders.UserSecretsConfigBuilder, Microsoft.Configuration.ConfigurationBuilders.UserSecrets" />
-      <add name="Json" jsonFile="${JSONConfigFile}" optional="true" type="Microsoft.Configuration.ConfigurationBuilders.SimpleJsonConfigBuilder, Microsoft.Configuration.ConfigurationBuilders.Json" />
+      <add name="Json" jsonFile="${JSONConfigFile}" enabled="${Boolean}" type="Microsoft.Configuration.ConfigurationBuilders.SimpleJsonConfigBuilder, Microsoft.Configuration.ConfigurationBuilders.Json" />
       <add name="KeyPerFile" directoryPath="~/../KeyPerFileSampleRoot" mode="Strict" keyDelimiter="--" type="Microsoft.Configuration.ConfigurationBuilders.KeyPerFileConfigBuilder, Microsoft.Configuration.ConfigurationBuilders.KeyPerFile" />
       <add name="KV1" vaultName="${ConfigBuilderTestKeyVaultName}" type="Microsoft.Configuration.ConfigurationBuilders.AzureKeyVaultConfigBuilder, Microsoft.Configuration.ConfigurationBuilders.Azure" />
       <add name="KV2" vaultName="${ConfigBuilderTestKeyVaultName}" preloadSecretNames="false" version="d14197de791c4ffe8e79bc7fc0f766b0" type="Microsoft.Configuration.ConfigurationBuilders.AzureKeyVaultConfigBuilder, Microsoft.Configuration.ConfigurationBuilders.Azure" />
       <add name="KV3" vaultName="${ConfigBuilderTestKeyVaultName}" mode="Greedy" type="Microsoft.Configuration.ConfigurationBuilders.AzureKeyVaultConfigBuilder, Microsoft.Configuration.ConfigurationBuilders.Azure" />
       <add name="KV4" vaultName="${ConfigBuilderTestKeyVaultName}" mode="Greedy" version="0de51928e49144ce86eb1de9056ac937" type="Microsoft.Configuration.ConfigurationBuilders.AzureKeyVaultConfigBuilder, Microsoft.Configuration.ConfigurationBuilders.Azure" />
-      <add name="AS_Sub_Test" optional="${Boolean}" type="Microsoft.Configuration.ConfigurationBuilders.EnvironmentConfigBuilder, Microsoft.Configuration.ConfigurationBuilders.Environment" />
-      <add name="AS_Sub_Test2" optional="${app~Settings_Colon-and$friends@super+duper,awesome#cool:Test.}" type="Microsoft.Configuration.ConfigurationBuilders.EnvironmentConfigBuilder, Microsoft.Configuration.ConfigurationBuilders.Environment" />
+      <add name="AS_Sub_Test" enabled="${Optional}" type="Microsoft.Configuration.ConfigurationBuilders.EnvironmentConfigBuilder, Microsoft.Configuration.ConfigurationBuilders.Environment" />
+      <add name="AS_Sub_Test2" enabled="${app~Settings_Colon-and$friends@super+duper,awesome#cool:Test.}" type="Microsoft.Configuration.ConfigurationBuilders.EnvironmentConfigBuilder, Microsoft.Configuration.ConfigurationBuilders.Environment" />
       <add name="ExpTest" mode="Expand" escapeExpandedValues="true" jsonFile="~/App_Data/expandTest.json" jsonMode="Flat" type="Microsoft.Configuration.ConfigurationBuilders.SimpleJsonConfigBuilder, Microsoft.Configuration.ConfigurationBuilders.Json" />
       <add name="appconfig1" endpoint="${AppConfigTestEndpoint}" keyFilter="acTes*" type="Microsoft.Configuration.ConfigurationBuilders.AzureAppConfigurationBuilder, Microsoft.Configuration.ConfigurationBuilders.AzureAppConfiguration" />
-      <add name="appconfig2" optional="false" endpoint="${AppConfigTestEndpoint}" mode="Greedy" labelFilter="beta" useAzureKeyVault="true" type="Microsoft.Configuration.ConfigurationBuilders.AzureAppConfigurationBuilder, Microsoft.Configuration.ConfigurationBuilders.AzureAppConfiguration" />
+      <add name="appconfig2" enabled="true" endpoint="${AppConfigTestEndpoint}" mode="Greedy" labelFilter="beta" useAzureKeyVault="true" type="Microsoft.Configuration.ConfigurationBuilders.AzureAppConfigurationBuilder, Microsoft.Configuration.ConfigurationBuilders.AzureAppConfiguration" />
       <add name="appconfig3" endpoint="${AppConfigTestEndpoint}" mode="Greedy" keyFilter="acLM*" acceptDateTime="December 6, 2019" type="Microsoft.Configuration.ConfigurationBuilders.AzureAppConfigurationBuilder, Microsoft.Configuration.ConfigurationBuilders.AzureAppConfiguration" />
     </builders>
   </configBuilders>
   <appSettings configBuilders="Environment,Secrets,Json,KeyPerFile,KV1,KV2,KV3,KV4">
-    <add key="app~Settings_Colon-and$friends@super+duper,awesome#cool:Test." value="true" />
+    <add key="app~Settings_Colon-and$friends@super+duper,awesome#cool:Test." value="optional" />
     <add key="WINDIR" value="Will be replaced by 'Environment' in Strict and Greedy modes." />
     <add key="SYSTEMDRIVE" value="Will initally be replaced by 'Environment' in Strict and Greedy modes... but then superceded by 'Secrets' in the same modes." />
     <add key="Value_Replaced_By_Environment_In_Expand_Mode" value="${WINDIR}" />

--- a/src/Azure/AzureKeyVaultConfigBuilder.cs
+++ b/src/Azure/AzureKeyVaultConfigBuilder.cs
@@ -43,8 +43,8 @@ namespace Microsoft.Configuration.ConfigurationBuilders
         /// <param name="config">A collection of the name/value pairs representing builder-specific attributes specified in the configuration for this provider.</param>
         protected override void LazyInitialize(string name, NameValueCollection config)
         {
-            // Default 'Optional' to false. base.LazyInitialize() will override if specified in config.
-            Optional = false;
+            // Default to 'Enabled'. base.LazyInitialize() will override if specified in config.
+            Enabled = KeyValueEnabled.Enabled;
 
             base.LazyInitialize(name, config);
 
@@ -63,7 +63,7 @@ namespace Microsoft.Configuration.ConfigurationBuilders
             {
                 if (String.IsNullOrWhiteSpace(_vaultName))
                 {
-                    if (Optional)
+                    if (IsOptional)
                     {
                         return;
                     }
@@ -93,7 +93,7 @@ namespace Microsoft.Configuration.ConfigurationBuilders
             }
             catch (Exception)
             {
-                if (!Optional)
+                if (!IsOptional)
                     throw;
                 _kvClient = null;
             }
@@ -224,7 +224,7 @@ namespace Microsoft.Configuration.ConfigurationBuilders
 
                     // If there was a permission issue or some other error, let the exception bubble
                     // FYI: kve.Body.Error.Code == "Forbidden" :: No Rights, or secret is disabled.
-                    if (!Optional)
+                    if (!IsOptional)
                         throw;
                 }
             }
@@ -257,7 +257,7 @@ namespace Microsoft.Configuration.ConfigurationBuilders
                 if (rfex.ErrorCode == "Forbidden")
                     return keys;
 
-                if (!Optional)
+                if (!IsOptional)
                     throw;
             }
 

--- a/src/AzureAppConfig/AzureAppConfigurationBuilder.cs
+++ b/src/AzureAppConfig/AzureAppConfigurationBuilder.cs
@@ -51,8 +51,8 @@ namespace Microsoft.Configuration.ConfigurationBuilders
         /// <param name="config">A collection of the name/value pairs representing builder-specific attributes specified in the configuration for this provider.</param>
         protected override void LazyInitialize(string name, NameValueCollection config)
         {
-            // Default 'Optional' to false. base.LazyInitialize() will override if specified in config.
-            Optional = false;
+            // Default to 'Enabled'. base.LazyInitialize() will override if specified in config.
+            Enabled = KeyValueEnabled.Enabled;
 
             base.LazyInitialize(name, config);
 
@@ -101,7 +101,7 @@ namespace Microsoft.Configuration.ConfigurationBuilders
                     }
                     catch (Exception ex)
                     {
-                        if (!Optional)
+                        if (!IsOptional)
                             throw new ArgumentException($"Exception encountered while creating connection to Azure App Configuration store.", ex);
                     }
                 }
@@ -119,7 +119,7 @@ namespace Microsoft.Configuration.ConfigurationBuilders
                 }
                 catch (Exception ex)
                 {
-                    if (!Optional)
+                    if (!IsOptional)
                         throw new ArgumentException($"Exception encountered while creating connection to Azure App Configuration store.", ex);
                 }
             }
@@ -242,7 +242,7 @@ namespace Microsoft.Configuration.ConfigurationBuilders
                             // 'Optional' plays a double role with this provider. Being optional means it is
                             // ok for us to fail to resolve a keyvault reference. If we are not optional though,
                             // we want to make some noise when a reference fails to resolve.
-                            if (!Optional)
+                            if (!IsOptional)
                                 throw;
                         }
                     }
@@ -254,7 +254,7 @@ namespace Microsoft.Configuration.ConfigurationBuilders
                     await enumerator.DisposeAsync();
                 }
             }
-            catch (Exception e) when (Optional && ((e.InnerException is System.Net.Http.HttpRequestException) || (e.InnerException is UnauthorizedAccessException))) { }
+            catch (Exception e) when (IsOptional && ((e.InnerException is System.Net.Http.HttpRequestException) || (e.InnerException is UnauthorizedAccessException))) { }
 
             return null;
         }
@@ -309,7 +309,7 @@ namespace Microsoft.Configuration.ConfigurationBuilders
                                 // 'Optional' plays a double role with this provider. Being optional means it is
                                 // ok for us to fail to resolve a keyvault reference. If we are not optional though,
                                 // we want to make some noise when a reference fails to resolve.
-                                if (!Optional)
+                                if (!IsOptional)
                                     throw;
                             }
                         }
@@ -323,7 +323,7 @@ namespace Microsoft.Configuration.ConfigurationBuilders
                     await enumerator.DisposeAsync();
                 }
             }
-            catch (Exception e) when (Optional && ((e.InnerException is System.Net.Http.HttpRequestException) || (e.InnerException is UnauthorizedAccessException))) { }
+            catch (Exception e) when (IsOptional && ((e.InnerException is System.Net.Http.HttpRequestException) || (e.InnerException is UnauthorizedAccessException))) { }
 
             return data;
         }
@@ -349,7 +349,7 @@ namespace Microsoft.Configuration.ConfigurationBuilders
 
             // TODO: Check to see if SecretClient can take the full uri instead of requiring us to parse out the secretID.
             SecretClient kvClient = GetSecretClient(vaultUri);
-            if (kvClient == null && !Optional)
+            if (kvClient == null && !IsOptional)
                 throw new RequestFailedException("Could not connect to Azure Key Vault while retrieving secret. Connection is not optional.");
 
             // Retrieve Value

--- a/src/Base/Base.csproj
+++ b/src/Base/Base.csproj
@@ -42,6 +42,7 @@
     <Reference Include="System.Xml" />
   </ItemGroup>
   <ItemGroup>
+    <Compile Include="KeyValueEnabled.cs" />
     <Compile Include="KeyValueExceptions.cs" />
     <Compile Include="SectionHandler.cs" />
     <Compile Include="SectionHandlerSection.cs" />

--- a/src/Base/KeyValueEnabled.cs
+++ b/src/Base/KeyValueEnabled.cs
@@ -1,0 +1,34 @@
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT license. See the License.txt file in the project root for full license information.
+
+namespace Microsoft.Configuration.ConfigurationBuilders
+{
+    /// <summary>
+    /// Possible modes (or behaviors) for key/value substitution.
+    /// </summary>
+    public enum KeyValueEnabled
+    {
+        /// <summary>
+        /// Will execute KeyValueConfigurationBuilder and throw on error.
+        /// </summary>
+        Enabled,
+        /// <summary>
+        /// Will not execute KeyValueConfigurationBuilder.
+        /// </summary>
+        Disabled,
+        /// <summary>
+        /// Will execute KeyValueConfigurationBuilder but not report errors.
+        /// </summary>
+        Optional,
+
+        // For convenience, allow true/false in the builder attribute as well.
+        /// <summary>
+        /// Same as Enabled.
+        /// </summary>
+        True = Enabled,
+        /// <summary>
+        /// Same as Disabled.
+        /// </summary>
+        False = Disabled
+    }
+}

--- a/src/Environment/EnvironmentConfigBuilder.cs
+++ b/src/Environment/EnvironmentConfigBuilder.cs
@@ -25,7 +25,7 @@ namespace Microsoft.Configuration.ConfigurationBuilders
             }
             catch (Exception)
             {
-                if (!Optional)
+                if (!IsOptional)
                     throw;
             }
 
@@ -52,7 +52,7 @@ namespace Microsoft.Configuration.ConfigurationBuilders
             }
             catch (Exception)
             {
-                if (!Optional)
+                if (!IsOptional)
                     throw;
             }
 

--- a/src/Json/SimpleJsonConfigBuilder.cs
+++ b/src/Json/SimpleJsonConfigBuilder.cs
@@ -55,7 +55,7 @@ namespace Microsoft.Configuration.ConfigurationBuilders
             JsonFile = Utils.MapPath(jsonFile, CurrentSection);
             if (!File.Exists(JsonFile))
             {
-                if (Optional)
+                if (IsOptional)
                 {
                     // This empty dictionary allows us to effectively no-op any attempt to get values.
                     _allSettings[""] = new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase);

--- a/src/KeyPerFile/KeyPerFileConfigBuilder.cs
+++ b/src/KeyPerFile/KeyPerFileConfigBuilder.cs
@@ -45,14 +45,14 @@ namespace Microsoft.Configuration.ConfigurationBuilders
         /// <param name="config">A collection of the name/value pairs representing builder-specific attributes specified in the configuration for this provider.</param>
         protected override void LazyInitialize(string name, NameValueCollection config)
         {
-            // Default 'Optional' to false. base.Initialize() will override if specified in config.
-            Optional = false;
+            // Default to 'Enabled'. base.Initialize() will override if specified in config.
+            Enabled = KeyValueEnabled.Enabled;
 
             base.LazyInitialize(name, config);
 
             string directoryPath = UpdateConfigSettingWithAppSettings(directoryPathTag);
             DirectoryPath = Utils.MapPath(directoryPath, CurrentSection);
-            if (!Optional && (String.IsNullOrEmpty(DirectoryPath) || !Directory.Exists(DirectoryPath)))
+            if (!IsOptional && (String.IsNullOrEmpty(DirectoryPath) || !Directory.Exists(DirectoryPath)))
             {
                 throw new ArgumentException($"'directoryPath' does not exist.");
             }

--- a/src/UserSecrets/UserSecretsConfigBuilder.cs
+++ b/src/UserSecrets/UserSecretsConfigBuilder.cs
@@ -55,7 +55,7 @@ namespace Microsoft.Configuration.ConfigurationBuilders
             {
                 ReadUserSecrets(UserSecretsFile);
             }
-            else if (!Optional)
+            else if (!IsOptional)
             {
                 throw new ArgumentException($"Secrets file does not exist.");
             }


### PR DESCRIPTION
Migrate to use 'enabled' instead of 'optional'. This new concept somewhat overlaps with the
optional concept, but allows for complete disabling of builders which can be useful in
build and staging environments.