### PR TITLE
Fix retrieval of current value in sample ClientSettingsSectionHandler.

### DIFF
--- a/samples/SampleSectionHandlers/ClientSettingsSectionHandler.cs
+++ b/samples/SampleSectionHandlers/ClientSettingsSectionHandler.cs
@@ -61,7 +61,7 @@ namespace SampleSectionHandlers
             ConfigSection.Settings.CopyTo(allSettings, 0);
 
             foreach (SettingElement setting in allSettings)
-                yield return Tuple.Create(setting.Name, setting.Value?.ToString(), (object)setting);
+                yield return Tuple.Create(setting.Name, setting.Value?.ValueXml?.InnerXml, (object)setting);
         }
 
         /// <summary>


### PR DESCRIPTION
We were retrieving a type-name instead of actual text value in the sample ClientSettingsSectionHandler.