### PR TITLE
Add ExpandWrapper sample.

### DIFF
--- a/MicrosoftConfigurationBuilders.msbuild
+++ b/MicrosoftConfigurationBuilders.msbuild
@@ -15,8 +15,8 @@
   </ItemGroup>
 
   <ItemGroup>
-    <SampleProject Include="samples\SampleSectionHandlers\SampleSectionHandlers.csproj" />
     <SampleProject Include="samples\SampleConsoleApp\SampleConsoleApp.csproj" />
+    <SampleProject Include="samples\SamplesLib\SamplesLib.csproj" />
     <SampleProject Include="samples\SampleWebApp\SampleWebApp.csproj" />
     <SampleProject Include="samples\SampleWebJob\SampleWebJob.csproj" />
   </ItemGroup>

--- a/MicrosoftConfigurationBuilders.sln
+++ b/MicrosoftConfigurationBuilders.sln
@@ -91,8 +91,6 @@ Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "SampleWebJob", "samples\Sam
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "SampleConsoleApp", "samples\SampleConsoleApp\SampleConsoleApp.csproj", "{0DBFA194-1632-40C0-A072-C59A9280412B}"
 EndProject
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "SampleSectionHandlers", "samples\SampleSectionHandlers\SampleSectionHandlers.csproj", "{B3F1C0AD-957B-4453-A830-F104FE368BC4}"
-EndProject
 Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "docs", "docs", "{905D083F-6414-4DEA-9779-76C8A2518F8D}"
 	ProjectSection(SolutionItems) = preProject
 		docs\CustomConfigBuilders.md = docs\CustomConfigBuilders.md
@@ -101,6 +99,8 @@ Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "docs", "docs", "{905D083F-6
 		docs\KeyValueConfigBuilders.md = docs\KeyValueConfigBuilders.md
 		docs\SectionHandlers.md = docs\SectionHandlers.md
 	EndProjectSection
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "SamplesLib", "samples\SamplesLib\SamplesLib.csproj", "{BAA5EB76-5A85-48D6-9E8F-A01A309A2879}"
 EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
@@ -156,10 +156,10 @@ Global
 		{0DBFA194-1632-40C0-A072-C59A9280412B}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{0DBFA194-1632-40C0-A072-C59A9280412B}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{0DBFA194-1632-40C0-A072-C59A9280412B}.Release|Any CPU.Build.0 = Release|Any CPU
-		{B3F1C0AD-957B-4453-A830-F104FE368BC4}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
-		{B3F1C0AD-957B-4453-A830-F104FE368BC4}.Debug|Any CPU.Build.0 = Debug|Any CPU
-		{B3F1C0AD-957B-4453-A830-F104FE368BC4}.Release|Any CPU.ActiveCfg = Release|Any CPU
-		{B3F1C0AD-957B-4453-A830-F104FE368BC4}.Release|Any CPU.Build.0 = Release|Any CPU
+		{BAA5EB76-5A85-48D6-9E8F-A01A309A2879}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{BAA5EB76-5A85-48D6-9E8F-A01A309A2879}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{BAA5EB76-5A85-48D6-9E8F-A01A309A2879}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{BAA5EB76-5A85-48D6-9E8F-A01A309A2879}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE
@@ -171,7 +171,7 @@ Global
 		{B2D778B6-6E0A-4ED1-B1E3-7C85DD976F69} = {DFB1983C-B754-403E-AECC-ED3D4C9DC42A}
 		{18D8B490-1CBC-4783-B6D7-D1A88E832224} = {2F759F48-7F89-4811-8F94-380BCCC83C69}
 		{0DBFA194-1632-40C0-A072-C59A9280412B} = {2F759F48-7F89-4811-8F94-380BCCC83C69}
-		{B3F1C0AD-957B-4453-A830-F104FE368BC4} = {2F759F48-7F89-4811-8F94-380BCCC83C69}
+		{BAA5EB76-5A85-48D6-9E8F-A01A309A2879} = {2F759F48-7F89-4811-8F94-380BCCC83C69}
 	EndGlobalSection
 	GlobalSection(ExtensibilityGlobals) = postSolution
 		SolutionGuid = {6380A53F-A088-4D0B-B415-C8D16222F022}

--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ linked here:
 
 <a name="updates"></a>
 ### V3 Updates:
-  * :warning: ***Breaking Change*** - `Expand` mode is gone. It has been [replaced by `Token` mode](docs/KeyValueConfigBuilders.md#token).#TODO verify link (and #enabled and #charmap link)
+  * :warning: ***Breaking Change*** - `Expand` mode is gone. It has been [replaced by `Token` mode](docs/KeyValueConfigBuilders.md#mode).
   * `Utils.MapPath` - This was somewhat broken in ASP.Net scenarios previously. It should now reliably go against `Server.MapPath()` in ASP.Net scenarios. It has
         also been updated to fall back against the directory of the config file being processed when resolving the app root in the case of a `Configuration`
         object being created by `ConfigurationManager.OpenConfiguration*` API's rather than being part of a fully-initialized runtime configuration stack.

--- a/docs/FAQ.md
+++ b/docs/FAQ.md
@@ -22,6 +22,15 @@ some of the most frequent along with answers that are hopefully helpful.
 >  To make things simpler across the board, 'Expand' mode was replaced with 'Token' mode which should
 >  operate in a fairly similar manner with the added benefit of being less prone to producing invalid
 >  XML to muck things up. :smiley:
+>
+> <sup><sub>
+> If you really, really need that raw plain-text processing because it's not possible to write an
+> `ISectionHandler` for your particular section, or because you have taken full advantage of building
+> xml through the use of token expansion that doesn't conform to the convenient mental paradigm of
+> only placing tokens within obvious key/value places of existing well-formed xml... you can try
+> [this wrapper approach](../samples/SamplesLib/ExpandWrapper.cs) as is demonstrated in the
+> [SampleConsoleApp](../samples/SampleConsoleApp/App.config#L36-L39).
+> </sub></sub>
 </details>
 
 <a name="newhandler"></a>
@@ -47,7 +56,7 @@ some of the most frequent along with answers that are hopefully helpful.
 >  isn't really a standard .Net configuration section like it appears to be on first glance. The classes
 >  that support ApplicationSettings provide a strict and strongly typed window into what looks like a
 >  standard configuration section in your app.config file. While we can easily write a section handler
->  for the `ClientSettingsSection` ([example](../samples/SampleSectionHandlers/ClientSettingsSectionHandler.cs))
+>  for the `ClientSettingsSection` ([example](../samples/SamplesLib/ClientSettingsSectionHandler.cs))
 >  it won't integrate into the ApplicationSettings framework seamlessly like one might expect. The
 >  ApplicationSetting framework has already determined the number and names (including casing, which
 >  is problematic in 'Greedy' mode) of all the settings it will present before the base configuration
@@ -55,7 +64,7 @@ some of the most frequent along with answers that are hopefully helpful.
 >  mode, and you can't override existing values in 'Greedy' mode if you don't properly match
 >  casing - despite the fact that ApplicationSettings is supposed to be case-insensitive.
 >
->  If you wish, you can use the [sample section handler](../samples/SampleSectionHandlers/ClientSettingsSectionHandler.cs)
+>  If you wish, you can use the [sample section handler](../samples/SamplesLib/ClientSettingsSectionHandler.cs)
 >  to process ApplicationSettings in your application, but know that the use case is rather limited.
 >  It will work in 'Strict' mode... and maybe require some prodding to force the ApplicationSettings
 >  framework to forget the settings it's seen before and decide to look back into the config file to

--- a/samples/SampleConsoleApp/App.config
+++ b/samples/SampleConsoleApp/App.config
@@ -5,6 +5,7 @@
     <section name="configBuilders" type="System.Configuration.ConfigurationBuildersSection, System.Configuration, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a" restartOnExternalChanges="false" requirePermission="false" />
     <section name="Microsoft.Configuration.ConfigurationBuilders.SectionHandlers" type="Microsoft.Configuration.ConfigurationBuilders.SectionHandlersSection, Microsoft.Configuration.ConfigurationBuilders.Base" restartOnExternalChanges="false" requirePermission="false" />
     <section name="customSettings" type="System.Configuration.AppSettingsSection, System.Configuration, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a" restartOnExternalChanges="false" requirePermission="false" />
+    <section name="expandedSettings" type="System.Configuration.AppSettingsSection, System.Configuration, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a" restartOnExternalChanges="false" requirePermission="false" />
     <sectionGroup name="applicationSettings" type="System.Configuration.ApplicationSettingsGroup, System, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089" >
       <section name="SampleConsoleApp.ClientSettings" type="System.Configuration.ClientSettingsSection, System, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089" requirePermission="false" />
     </sectionGroup>
@@ -15,12 +16,13 @@
       <add name="Env" type="Microsoft.Configuration.ConfigurationBuilders.EnvironmentConfigBuilder, Microsoft.Configuration.ConfigurationBuilders.Environment" />
       <add name="KeyPerFile" mode="Greedy" directoryPath="${SampleItems}/KeyPerFileRoot" type="Microsoft.Configuration.ConfigurationBuilders.KeyPerFileConfigBuilder, Microsoft.Configuration.ConfigurationBuilders.KeyPerFile" />
       <add name="Json" mode="Greedy" jsonMode="Flat" jsonFile="${jsonFile}" type="Microsoft.Configuration.ConfigurationBuilders.SimpleJsonConfigBuilder, Microsoft.Configuration.ConfigurationBuilders.Json" />
+      <add name="JsonExpand" mode="Token" jsonMode="Sectional" jsonFile="${jsonFile}"  type="SamplesLib.ExpandWrapper`1[[Microsoft.Configuration.ConfigurationBuilders.SimpleJsonConfigBuilder, Microsoft.Configuration.ConfigurationBuilders.Json]], SamplesLib" />
     </builders>
   </configBuilders>
 
   <Microsoft.Configuration.ConfigurationBuilders.SectionHandlers>
     <handlers>
-      <add name="ClientSettingsHandler" type="SampleSectionHandlers.ClientSettingsSectionHandler, SampleSectionHandlers" />
+      <add name="ClientSettingsHandler" type="SamplesLib.ClientSettingsSectionHandler, SamplesLib" />
     </handlers>
   </Microsoft.Configuration.ConfigurationBuilders.SectionHandlers>
 
@@ -30,6 +32,11 @@
   </appSettings>
 
   <customSettings configBuilders="Json" />
+
+  <expandedSettings configBuilders="JsonExpand">
+    ${expandedSetting1}
+    ${expandedSetting2}
+  </expandedSettings>
 
   <applicationSettings>
     <SampleConsoleApp.ClientSettings configBuilders="Env">

--- a/samples/SampleConsoleApp/Program.cs
+++ b/samples/SampleConsoleApp/Program.cs
@@ -27,6 +27,16 @@ namespace SampleConsoleApp
             Console.WriteLine("");
             Console.WriteLine("");
 
+            Console.WriteLine("---------- Expanded Settings ----------");
+            var expandedSettings = ConfigurationManager.GetSection("expandedSettings") as NameValueCollection;
+            foreach (string setting in expandedSettings.Keys)
+            {
+                Console.WriteLine($"{setting}\t{expandedSettings[setting]}");
+            }
+
+            Console.WriteLine("");
+            Console.WriteLine("");
+
             Console.WriteLine("---------- Client Application Settings ----------");
             Console.WriteLine("Note: These _might_ be inaccurate due to the additional layers of building and caching that the");
             Console.WriteLine("\tClient Application Settings framework uses. Read more about the Settings architecture");

--- a/samples/SampleConsoleApp/SampleConsoleApp.csproj
+++ b/samples/SampleConsoleApp/SampleConsoleApp.csproj
@@ -62,10 +62,6 @@
     </None>
   </ItemGroup>
   <ItemGroup>
-    <ProjectReference Include="..\SampleSectionHandlers\SampleSectionHandlers.csproj">
-      <Project>{b3f1c0ad-957b-4453-a830-f104fe368bc4}</Project>
-      <Name>SampleSectionHandlers</Name>
-    </ProjectReference>
     <ProjectReference Include="..\..\src\Base\Base.csproj">
       <Project>{f382fbf8-146d-4968-a199-90d37f9ef9a7}</Project>
       <Name>Base</Name>
@@ -85,6 +81,10 @@
     <ProjectReference Include="..\..\src\UserSecrets\UserSecrets.csproj">
       <Project>{c60d6cbb-d513-4692-81a6-0be5d45e4702}</Project>
       <Name>UserSecrets</Name>
+    </ProjectReference>
+    <ProjectReference Include="..\SamplesLib\SamplesLib.csproj">
+      <Project>{baa5eb76-5a85-48d6-9e8f-a01a309a2879}</Project>
+      <Name>SamplesLib</Name>
     </ProjectReference>
   </ItemGroup>
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />

--- a/samples/SampleWebApp/App_Data/settings.json
+++ b/samples/SampleWebApp/App_Data/settings.json
@@ -25,5 +25,10 @@
       "setting2": "Complex Setting 2",
       "jsonArrayOfSettings": [ "one", "two", "three" ]
     }
+  },
+
+  "expandedSettings": {
+    "expandedSetting1": "<add key=\"oldExpandMode\" value=\"Is dead.\" />",
+    "expandedSetting2": "<add key=\"longLiving\" value=\"Old Expand Mode!\" />"
   }
 }

--- a/samples/SamplesLib/ClientSettingsSectionHandler.cs
+++ b/samples/SamplesLib/ClientSettingsSectionHandler.cs
@@ -5,7 +5,7 @@ using System.Linq;
 using System.Xml;
 using Microsoft.Configuration.ConfigurationBuilders;
 
-namespace SampleSectionHandlers
+namespace SamplesLib
 {
     /// <summary>
     /// A class that can be used by <see cref="KeyValueConfigBuilder"/>s to apply key/value config pairs to <see cref="ClientSettingsSection"/>.

--- a/samples/SamplesLib/ExpandWrapper.cs
+++ b/samples/SamplesLib/ExpandWrapper.cs
@@ -1,0 +1,67 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Collections.Specialized;
+using System.Configuration;
+using System.Linq;
+using System.Reflection;
+using System.Xml;
+using Microsoft.Configuration.ConfigurationBuilders;
+
+namespace SamplesLib
+{
+    public class ExpandWrapper<T> : ConfigurationBuilder where T : KeyValueConfigBuilder, new()
+    {
+        private static MethodInfo _expandTokensMethod = typeof(KeyValueConfigBuilder).GetMethod("ExpandTokens", BindingFlags.NonPublic | BindingFlags.Instance);
+        private T _underlyingBuilder;
+
+        public ExpandWrapper() { _underlyingBuilder = new T(); }
+
+        public override void Initialize(string name, NameValueCollection config) => _underlyingBuilder.Initialize(name, config);
+
+        public override XmlNode ProcessRawXml(XmlNode rawXml)
+        {
+            rawXml = _underlyingBuilder.ProcessRawXml(rawXml);
+
+            // !!!DO NOT APPLY TO APPSETTINGS!!!
+            // AppSettings is special because it can be implicitly referenced when looking for config builder
+            // settings, while it can simultaneously be processed by config builders. There used to be special
+            // logic to help manage potential recursion in the base KeyValueConfigBuilder class, but that
+            // protection is no more since 'Expand' mode and the use of _both_ ProcessRawXml() and ProcessConfigSection()
+            // have been removed.
+            if (rawXml.Name != "appSettings")    // System.Configuration hard codes this, so we might as well too.
+            {
+                // Checking Enabled will kick off LazyInit, so only do that if we are actually going to do work here.
+                if (_underlyingBuilder.Mode == KeyValueMode.Token && _underlyingBuilder.Enabled != KeyValueEnabled.Disabled)
+                {
+                    // Old Expand-mode would do a recursion check here. We don't have internal access to RecursionGuard.
+                    return ExpandTokens(rawXml);
+                }
+            }
+
+            return rawXml;
+        }
+
+        public override ConfigurationSection ProcessConfigurationSection(ConfigurationSection configSection)
+        {
+            // We have overridden the meaning of "Token" mode for this class. Don't do any processing in that mode.
+            if (_underlyingBuilder.Mode == KeyValueMode.Token)
+                return configSection;
+
+            return _underlyingBuilder.ProcessConfigurationSection(configSection);
+        }
+
+        private XmlNode ExpandTokens(XmlNode rawXml)
+        {
+            string rawXmlString = rawXml.OuterXml;
+            if (String.IsNullOrEmpty(rawXmlString))
+                return rawXml;
+
+            string updatedXmlString = (string)_expandTokensMethod.Invoke(_underlyingBuilder, new object[] { rawXmlString });
+
+            XmlDocument doc = new XmlDocument();
+            doc.PreserveWhitespace = true;
+            doc.LoadXml(updatedXmlString);
+            return doc.DocumentElement;
+        }
+    }
+}

--- a/samples/SamplesLib/Properties/AssemblyInfo.cs
+++ b/samples/SamplesLib/Properties/AssemblyInfo.cs
@@ -5,11 +5,11 @@ using System.Runtime.InteropServices;
 // General Information about an assembly is controlled through the following
 // set of attributes. Change these attribute values to modify the information
 // associated with an assembly.
-[assembly: AssemblyTitle("SampleSectionHandlers")]
+[assembly: AssemblyTitle("SamplesLib")]
 [assembly: AssemblyDescription("")]
 [assembly: AssemblyConfiguration("")]
 [assembly: AssemblyCompany("Microsoft IT")]
-[assembly: AssemblyProduct("SampleSectionHandlers")]
+[assembly: AssemblyProduct("SamplesLib")]
 [assembly: AssemblyCopyright("Copyright © Microsoft IT 2022")]
 [assembly: AssemblyTrademark("")]
 [assembly: AssemblyCulture("")]

--- a/samples/SamplesLib/SamplesLib.csproj
+++ b/samples/SamplesLib/SamplesLib.csproj
@@ -4,11 +4,11 @@
   <PropertyGroup>
     <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
     <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
-    <ProjectGuid>{B3F1C0AD-957B-4453-A830-F104FE368BC4}</ProjectGuid>
+    <ProjectGuid>{BAA5EB76-5A85-48D6-9E8F-A01A309A2879}</ProjectGuid>
     <OutputType>Library</OutputType>
     <AppDesignerFolder>Properties</AppDesignerFolder>
-    <RootNamespace>SampleSectionHandlers</RootNamespace>
-    <AssemblyName>SampleSectionHandlers</AssemblyName>
+    <RootNamespace>SamplesLib</RootNamespace>
+    <AssemblyName>SamplesLib</AssemblyName>
     <TargetFrameworkVersion>v4.7.1</TargetFrameworkVersion>
     <FileAlignment>512</FileAlignment>
     <Deterministic>true</Deterministic>
@@ -42,6 +42,7 @@
     <Reference Include="System.Xml" />
   </ItemGroup>
   <ItemGroup>
+    <Compile Include="ExpandWrapper.cs" />
     <Compile Include="ClientSettingsSectionHandler.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
   </ItemGroup>
@@ -49,6 +50,10 @@
     <ProjectReference Include="..\..\src\Base\Base.csproj">
       <Project>{f382fbf8-146d-4968-a199-90d37f9ef9a7}</Project>
       <Name>Base</Name>
+    </ProjectReference>
+    <ProjectReference Include="..\..\src\Json\Json.csproj">
+      <Project>{84e0ce5d-4af2-414f-a940-22b3f93fc727}</Project>
+      <Name>Json</Name>
     </ProjectReference>
   </ItemGroup>
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />


### PR DESCRIPTION
When mulling over removing the old 'Expand' mode my thoughts were that it wouldn't be that hard to bring it back in your own custom config builder. It's just a simple string replace in the `ProcessRawXml` override.

There are still good reasons in non-simple scenarios to avoid doing things in both `ProcessRawXml` and `ProcessConfigurationSection`, so `Expand` mode is still out of favor. But I can see some niche cases where it would be nice to have it back. For those cases, give this just-a-concept-not-fully-supported-sample ExpandWrapper a try.