### PR TITLE
Add overload for SecretClientOptions and ConfigurationClientOptions.

### DIFF
--- a/src/Azure/AzureKeyVaultConfigBuilder.cs
+++ b/src/Azure/AzureKeyVaultConfigBuilder.cs
@@ -122,7 +122,7 @@ namespace Microsoft.Configuration.ConfigurationBuilders
             // Connect to KeyVault
             try
             {
-                _kvClient = new SecretClient(new Uri(Uri), GetCredential());
+                _kvClient = new SecretClient(new Uri(Uri), GetCredential(), GetSecretClientOptions());
             }
             catch (Exception)
             {
@@ -164,6 +164,14 @@ namespace Microsoft.Configuration.ConfigurationBuilders
         /// </summary>
         /// <returns>A token credential.</returns>
         protected virtual TokenCredential GetCredential() => new DefaultAzureCredential();
+        
+        /// <summary>
+        /// Gets a <see cref="SecretClientOptions"/> to initialize the Key Vault SecretClient with. This defaults to <see cref="null"/>.
+        /// </summary>
+        /// <returns>A token credential.</returns>
+        protected virtual SecretClientOptions GetSecretClientOptions() => null;
+        
+        
 
         /// <summary>
         /// Retrieves all known key/value pairs from the Key Vault where the key begins with with <paramref name="prefix"/>.

--- a/src/AzureAppConfig/AzureAppConfigurationBuilder.cs
+++ b/src/AzureAppConfig/AzureAppConfigurationBuilder.cs
@@ -114,7 +114,7 @@ namespace Microsoft.Configuration.ConfigurationBuilders
                 try
                 {
                     var uri = new Uri(Endpoint);
-                    _client = new ConfigurationClient(uri, GetCredential());
+                    _client = new ConfigurationClient(uri, GetCredential(), GetConfigurationClientOptions());
                 }
                 catch (Exception ex)
                 {
@@ -225,6 +225,12 @@ namespace Microsoft.Configuration.ConfigurationBuilders
         /// </summary>
         /// <returns>A token credential.</returns>
         protected virtual TokenCredential GetCredential() => new DefaultAzureCredential();
+        
+        /// <summary>
+        /// Gets a <see cref="ConfigurationClientOptions"/> to initialize the Key Vault SecretClient with. This defaults to <see cref="null"/>.
+        /// </summary>
+        /// <returns>A token credential.</returns>
+        protected virtual ConfigurationClientOptions GetConfigurationClientOptions() => null;
 
         private async Task<string> GetValueAsync(string key)
         {


### PR DESCRIPTION
Give the Azure config builders the ability to control more fine-grained connection options via their respective 'ClientOptions' classes.