### PR TITLE
Use default options for Azure clients.

### DIFF
--- a/src/Azure/AzureKeyVaultConfigBuilder.cs
+++ b/src/Azure/AzureKeyVaultConfigBuilder.cs
@@ -169,7 +169,7 @@ namespace Microsoft.Configuration.ConfigurationBuilders
         /// Gets a <see cref="SecretClientOptions"/> to initialize the Key Vault SecretClient with. This defaults to <see cref="null"/>.
         /// </summary>
         /// <returns>A token credential.</returns>
-        protected virtual SecretClientOptions GetSecretClientOptions() => null;
+        protected virtual SecretClientOptions GetSecretClientOptions() => new SecretClientOptions();
         
         
 

--- a/src/AzureAppConfig/AzureAppConfigurationBuilder.cs
+++ b/src/AzureAppConfig/AzureAppConfigurationBuilder.cs
@@ -230,7 +230,7 @@ namespace Microsoft.Configuration.ConfigurationBuilders
         /// Gets a <see cref="ConfigurationClientOptions"/> to initialize the Key Vault SecretClient with. This defaults to <see cref="null"/>.
         /// </summary>
         /// <returns>A token credential.</returns>
-        protected virtual ConfigurationClientOptions GetConfigurationClientOptions() => null;
+        protected virtual ConfigurationClientOptions GetConfigurationClientOptions() => new ConfigurationClientOptions();
 
         private async Task<string> GetValueAsync(string key)
         {


### PR DESCRIPTION
ConfigurationClient doesn't accept null. SecretClient does, but it just creates these same default options. So let's create defaults on both builders for consistency's sake.