### PR TITLE
Use CurrentConfiguration before ConfigurationManager

### DIFF
--- a/src/Base/KeyValueConfigBuilder.cs
+++ b/src/Base/KeyValueConfigBuilder.cs
@@ -215,6 +215,17 @@ namespace Microsoft.Configuration.ConfigurationBuilders
                 });
             }
 
+            // Try to use CurrentConfiguration before falling back to ConfigurationManager. Otherwise OpenConfiguration()
+            // scenarios won't work because we're looking in the wrong processes AppSettings.
+            else if (CurrentSection?.CurrentConfiguration?.AppSettings is AppSettingsSection currentAppSettings)
+            {
+                configValue = Regex.Replace(configValue, _tokenPattern, (m) =>
+                {
+                    string settingName = m.Groups[1].Value;
+                    return (currentAppSettings.Settings[settingName]?.Value ?? m.Groups[0].Value);
+                });
+            }
+
             // All other config sections can just go through ConfigurationManager to get app settings though. :)
             else
             {


### PR DESCRIPTION
Use CurrentConfiguration before ConfigurationManager when reading parameter values from AppSettings. Like #210, except in the 'reading parameters from AppSettings' code.

I believe these are the only two places we used ConfigurationManager to access config. (Which works perfectly fine when reading our own processes config - which is the case 9/10 times.)