### PR TITLE
Update markdown formatting.

### DIFF
--- a/docs/CustomConfigBuilders.md
+++ b/docs/CustomConfigBuilders.md
@@ -1,8 +1,6 @@
 # Implementing More Key/Value Config Builders
 
-If you don't see a config builder here that suits your needs, you can write your own. Referencing the `Basic` nuget package for this project will get you the base upon which
-all of these builders inherit. Most of the heavy-ish lifting and consistent behavior across key/value config builders comes from this base. Take a look at the code for more
-detail, but in many cases implementing a custom key/value config builder in this same vein is as easy as inheriting the base, and implementing two basic methods.
+If you don't see a config builder here that suits your needs, you can write your own. Referencing the `Basic` nuget package for this project will get you the base upon which all of these builders inherit. Most of the heavy-ish lifting and consistent behavior across key/value config builders comes from this base. Take a look at the code for more detail, but in many cases implementing a custom key/value config builder in this same vein is as easy as inheriting the base, and implementing two basic methods.
 ```CSharp
 using Microsoft.Configuration.ConfigurationBuilders;
 

--- a/docs/Intro.md
+++ b/docs/Intro.md
@@ -1,31 +1,14 @@
 # Configuration Builders In The .Net Framework
 
-Configuration Builders are a new feature of the full .Net Framework, introduced in .Net 4.7.1. You can read a quick overview of
-the concept in [this blog post](http://jeffreyfritz.com/2017/11/modern-configuration-for-asp-net-4-7-1-with-configurationbuilders/).
-The concept is pretty simple - the config system instantiates an object that gets a chance to craft configuration while loading each
-`ConfigurationSection`. The execution of the concept can get a little more complicated though, because of the old multi-layered and
-strongly-typed nature of the old .Net Framework config system.
+Configuration Builders are a new feature of the full .Net Framework, introduced in .Net 4.7.1. You can read a quick overview of the concept in [this blog post](http://jeffreyfritz.com/2017/11/modern-configuration-for-asp-net-4-7-1-with-configurationbuilders/). The concept is pretty simple - the config system instantiates an object that gets a chance to craft configuration while loading each `ConfigurationSection`. The execution of the concept can get a little more complicated though, because of the old multi-layered and strongly-typed nature of the old .Net Framework config system.
 
-This document will attempt to dig a little deeper into the mechanics of `ConfigurationBuilder` in the .Net Framework, in the hopes
-that it will help understand how the builders in this project work together to construct a more dynamic configuration environment
-for legacy apps in a modern landscape. The first step is to understand the order of execution when building a `ConfigurationSection`.
+This document will attempt to dig a little deeper into the mechanics of `ConfigurationBuilder` in the .Net Framework, in the hopes that it will help understand how the builders in this project work together to construct a more dynamic configuration environment for legacy apps in a modern landscape. The first step is to understand the order of execution when building a `ConfigurationSection`.
 
 
 ## ConfigurationBuilders Order of Execution
-This section is about how the .Net Framework uses `ConfigurationBuilder`s to build configuration sections for app consumption.
-The mechanics of how this all works affects the order in which config builders are applied and what sources of information they have
-to draw on as well as the look of the underlying config section they are modifying. Indeed, even in this project, features like reading
-builder parameters from `AppSettings` are potentially constrained by the way the .Net config system works.
+This section is about how the .Net Framework uses `ConfigurationBuilder`s to build configuration sections for app consumption. The mechanics of how this all works affects the order in which config builders are applied and what sources of information they have to draw on as well as the look of the underlying config section they are modifying. Indeed, even in this project, features like reading builder parameters from `AppSettings` are potentially constrained by the way the .Net config system works.
 
-Its very easy to think of the .Net configuration system as simply reading the `.config` file that comes with your application. But there is much more involved
-in this task. To start with, the .Net Framework uses a multi-layered configuration system. Whenever code asks for a `ConfigurationSection`, wether it is directly
-via `GetSection()` or indirectly through `ConfigurationManager`, the .Net Framework starts by reading the machine-wide configuration in the machine.config
-file installed in `%WINDIR%\Microsoft.NET\Framework[64]\v4.0.30319\Config`. The process then moves to the next level config file and modifies what it
-read from machine.config with updates from that next level. And so on and so forth. The process iterates through a well-known chain of config files before
-returning the resulting accumulation of configuration values from all levels. (There are actually *two* configuration systems in one within the .Net Framework.
-They are roughly the same with the most noticeable difference being the layers of config files being stacked together. The client configuration system consults
-user config files and app.exe.config files, while the web configuration system follows a chain of web.config files.) The following diagram demonstrates the
-high level concept for an ASP.Net application serving a page from a sub-directory.
+Its very easy to think of the .Net configuration system as simply reading the `.config` file that comes with your application. But there is much more involved in this task. To start with, the .Net Framework uses a multi-layered configuration system. Whenever code asks for a `ConfigurationSection`, wether it is directly via `GetSection()` or indirectly through `ConfigurationManager`, the .Net Framework starts by reading the machine-wide configuration in the machine.config file installed in `%WINDIR%\Microsoft.NET\Framework[64]\v4.0.30319\Config`. The process then moves to the next level config file and modifies what it read from machine.config with updates from that next level. And so on and so forth. The process iterates through a well-known chain of config files before returning the resulting accumulation of configuration values from all levels. (There are actually *two* configuration systems in one within the .Net Framework. They are roughly the same with the most noticeable difference being the layers of config files being stacked together. The client configuration system consults user config files and app.exe.config files, while the web configuration system follows a chain of web.config files.) The following diagram demonstrates the high level concept for an ASP.Net application serving a page from a sub-directory.
 
 ```
 GetSection()      +----------------+            +------------+            +------------+            +------------+
@@ -36,12 +19,7 @@ GetSection()      +----------------+            +------------+            +-----
                   +----------------+            +------------+            +------------+            +------------+
 ```
 
-That is a simple explanation of layered config. Even from this simple concept you can see how each layer builds on previous layers... but does not directly
-influence other layers. Which brings us to the first point wrt config builder execution order. <u>***ConfigurationBuilders execute only in the layer in which they
-are applied.***</u> This refers to the _application_ of a config builder. The _definition_ of a config builder will carry forward to every layer beyond the one in which
-it was defined, just like applicationSettings and connectionStrings carry forward to the next layer. But the `configBuilders` tag that is used to apply a config
-builder is not carried forward. It is executed at each level and then forgotten. The results of the config builder execution are carried forward in the config
-object passed to the next level.
+That is a simple explanation of layered config. Even from this simple concept you can see how each layer builds on previous layers... but does not directly influence other layers. Which brings us to the first point wrt config builder execution order. <u>***ConfigurationBuilders execute only in the layer in which they are applied.***</u> This refers to the _application_ of a config builder. The _definition_ of a config builder will carry forward to every layer beyond the one in which it was defined, just like applicationSettings and connectionStrings carry forward to the next layer. But the `configBuilders` tag that is used to apply a config builder is not carried forward. It is executed at each level and then forgotten. The results of the config builder execution are carried forward in the config object passed to the next level.
 
 There is of course more detail within each layer. Let's take a look at what happens in the `(app) web.config` layer in the diagram above:
 
@@ -61,20 +39,9 @@ There is of course more detail within each layer. Let's take a look at what happ
     (app) web.config         +------------> { ConfigurationSection Object* }
 ```
 
-The first thing to notice is that this layer takes a `ConfigurationSection` object from the previous layer as input. All *.config* files and config builder output
-from previous layers are reflected in this object. From here, the first step (A:) taken at this layer is to *read and process* the raw xml for the requested configuration
-section. If the section is encrypted, it is decrypted here. If the section resides in a different file via the `configSource` attribute, then the raw xml is read from
-that source. The *last* step of retrieving/processing the raw xml content is passing it through the configuration builder chain. <u>***The builder chain executes in
-the order that builders appear in the `configBuilders` tag for the section.***</u> The processed xml then returns into the config system where magic is applied to
-combine it with the `ConfigurationSection` object from the previous layer to produce a new `ConfigurationSection` object that reflects the merged settings.
-Lastly, this `ConfigurationSection` object is passed through the config builder chain, which executes in the same order as before. The resulting object gets passed
-on to the next layer if it exists.
+The first thing to notice is that this layer takes a `ConfigurationSection` object from the previous layer as input. All *.config* files and config builder output from previous layers are reflected in this object. From here, the first step (A:) taken at this layer is to *read and process* the raw xml for the requested configuration section. If the section is encrypted, it is decrypted here. If the section resides in a different file via the `configSource` attribute, then the raw xml is read from that source. The *last* step of retrieving/processing the raw xml content is passing it through the configuration builder chain. <u>***The builder chain executes in the order that builders appear in the `configBuilders` tag for the section.***</u> The processed xml then returns into the config system where magic is applied to combine it with the `ConfigurationSection` object from the previous layer to produce a new `ConfigurationSection` object that reflects the merged settings. Lastly, this `ConfigurationSection` object is passed through the config builder chain, which executes in the same order as before. The resulting object gets passed on to the next layer if it exists.
 
-One aspect to note is that config builders are instantiated once per appearance in a `configBuilders` tag. This means that if you apply the "same" config builder to
-both your `<appSettings/>` and `<connectionStrings/>` sections, each section will use a separate instance for processing since each section was tagged
-with the builder separately. Similarly, if you define an 'Environment' config builder in machine.config and apply it to `<appSettings/>` both there and
-again in app.exe.config... two separate instances will be created to process configuration at each layer. However, the same instance is used for processing both
-the raw xml as well as the `ConfigurationSection` object within each layer/section.
+One aspect to note is that config builders are instantiated once per appearance in a `configBuilders` tag. This means that if you apply the "same" config builder to both your `<appSettings/>` and `<connectionStrings/>` sections, each section will use a separate instance for processing since each section was tagged with the builder separately. Similarly, if you define an 'Environment' config builder in machine.config and apply it to `<appSettings/>` both there and again in app.exe.config... two separate instances will be created to process configuration at each layer. However, the same instance is used for processing both the raw xml as well as the `ConfigurationSection` object within each layer/section.
 
 Here is a brief pseudo-config example to demonstrate the order of execution:
 
@@ -83,8 +50,7 @@ Here is a brief pseudo-config example to demonstrate the order of execution:
 | check 1 | check 2 | bananas |
 | <pre>&lt;configBuilders&gt;<br/>&nbsp;&nbsp;&lt;add name="machine1" type=MachineA,..." /&gt;<br/>&nbsp;&nbsp;&lt;add name="machine2" type=MachineB,..." /&gt;<br/>&lt;/configBuilders&gt;<br/><br/>&lt;appSettings<br/>&nbsp;&nbsp;&nbsp;configBuilders="machine2, machine1" /&gt;</pre> | <pre>&lt;configBuilders&gt;<br/>&nbsp;&nbsp;&lt;remove name="machine2" /&gt;<br/>&nbsp;&nbsp;&lt;add name="machine2" type=WebTwo,..." /&gt;<br/>&nbsp;&nbsp;&lt;add name="web1" type=WebOne,..." /&gt;<br/>&lt;/configBuilders&gt;<br/><br/>&lt;appSettings<br/>&nbsp;&nbsp;&nbsp;configBuilders="web1" /&gt;</pre> | <pre>&lt;configBuilders&gt;<br/>&nbsp;&nbsp;&lt;add name="web3" type=WebThree,..." /&gt;<br/>&lt;/configBuilders&gt;<br/><br/>&lt;appSettings<br/>&nbsp;&nbsp;&nbsp;configBuilders="web3,machine2,web1" /&gt;</pre> |
 
-With the config layers above, loading the application settings for your web app would result in config builders executing in the following order. (InstanceId is a made
-up Id just for this table to demonstrate when instances are reused.)
+With the config layers above, loading the application settings for your web app would result in config builders executing in the following order. (InstanceId is a made up Id just for this table to demonstrate when instances are reused.)
 
 | Row&nbsp;# | BuilderName | Type | Instance&nbsp;# | Data Format | Data Source |
 | ---: | ----------- | ---- | ---------: | ----------: | ----------- |
@@ -103,28 +69,14 @@ up Id just for this table to demonstrate when instances are reused.)
 
 The `ConfigurationSection` object that returns from row 12 is the end result of config building.
 
-<a name="recursion"/>
+<a name="recursion"></a>
 ## Potential For Recursion/Overflow
 
-The discussion above all centers on the loading of a single `ConfigurationSection.` This simple conceptual model of how sections
-are loaded has served the framework well over the years. But one potential pitfall that arises from the extensibility introduced by *ConfigurationBuilders*
-is that config sections may not remain neatly separated anymore. In fact, the *KeyValueConfigBuilders* provided in this project offer
-a feature that explicitly entangles the creation of different config sections by allowing builders to draw upon `appSettings` for
-input parameters.
+The discussion above all centers on the loading of a single `ConfigurationSection.` This simple conceptual model of how sections are loaded has served the framework well over the years. But one potential pitfall that arises from the extensibility introduced by *ConfigurationBuilders* is that config sections may not remain neatly separated anymore. In fact, the *KeyValueConfigBuilders* provided in this project offer a feature that explicitly entangles the creation of different config sections by allowing builders to draw upon `appSettings` for input parameters.
 
 
-When sections are conceptually siloed, there are no concerns about deadlocks or overflows because there are no cycles created when
-sections remain completely untangled. Traditionally, code that defines a `ConfigurationSection` is encouraged to not use other configuration
-sections while creating thier own. Creating dependencies across sections can create complications when the order in which the sections
-get loaded is not determinate. Crossing streams is bad. 
+When sections are conceptually siloed, there are no concerns about deadlocks or overflows because there are no cycles created when sections remain completely untangled. Traditionally, code that defines a `ConfigurationSection` is encouraged to not use other configuration sections while creating thier own. Creating dependencies across sections can create complications when the order in which the sections get loaded is not determinate. Crossing streams is bad. 
 
-But the 'load from appSettings' feature in this project does just that. We also encourage folks who extend this package to use the coding skills
-they know to bring in information from external sources - and the classes/methods for doing so could also indirectly load another configuration
-section... or maybe even try to reload the section that is currently being loaded. The potential for deadlock and/or stack overflow is there if
-developers are not careful about what their config builders are doing.
+But the 'load from appSettings' feature in this project does just that. We also encourage folks who extend this package to use the coding skills they know to bring in information from external sources - and the classes/methods for doing so could also indirectly load another configuration section... or maybe even try to reload the section that is currently being loaded. The potential for deadlock and/or stack overflow is there if developers are not careful about what their config builders are doing.
 
-Unfortunately, there is not much we can do to prevent or neatly handle this situation. We have [seen it crop up in the past](#61) and it
-can be difficult to diagnose. Users of config builders should be aware of the possibility they might end up in a recursive loop of
-sections loading sections. In version 3 of this project there is a new [RecursionGuard](#TODO) feature that is enabled by default. It
-does not 'fix' or stop the recursion, but throws an exception to explain what's happening. It can optionally be configured to stop the
-recursion and continue... but using this option could yield non-deterministic results.
+Unfortunately, there is not much we can do to prevent or neatly handle this situation. We have [seen it crop up in the past](#61) and it can be difficult to diagnose. Users of config builders should be aware of the possibility they might end up in a recursive loop of sections loading sections. In version 3 of this project there is a new [RecursionGuard](#TODO) feature that is enabled by default. It does not 'fix' or stop the recursion, but throws an exception to explain what's happening. It can optionally be configured to stop the recursion and continue... but using this option could yield non-deterministic results.

--- a/docs/KeyValueConfigBuilders.md
+++ b/docs/KeyValueConfigBuilders.md
@@ -1,31 +1,31 @@
 # KeyValueConfigBuilders
 
+<a name="toc"></a>
+## Table of Contents
+  * [Introduction to Key/Value Config Builders](#introduction-to-keyvalue-config-builders)
+  * [AppSettings Parameters](#appsettings-parameters)
+  * [Config Builders In This Project](#config-builders-in-this-project)
+    - [Environment](environmentconfigbuilder)
+    - [UserSecrets](#usersecretsconfigbuilder)
+    - [Azure Builders](#azure-config-builders)
+      + [App Configuration](#azureappconfigurationbuilder)
+      + [Key Vault](#azurekeyvaultconfigbuilder)
+    - [KeyPerFile](#keyperfileconfigbuilder)
+    - [Json](#simplejsonconfigbuilder)
+
 <a name="intro"></a>
 ## Introduction to Key/Value Config Builders
 
-Introduced in .Net 4.7.1, `ConfigurationBuilders` is a feature that can be quite flexible. Applications can use the Configuration Builder
-concept to construct incredibly complex configuration on the fly. But for the most common usage scenarios, a basic key/value replacement mechanism is all that
-is needed. The config builders in this project are designed to be such simple key/value builders.
+Introduced in .Net 4.7.1, `ConfigurationBuilders` is a feature that can be quite flexible. Applications can use the Configuration Builder concept to construct incredibly complex configuration on the fly. But for the most common usage scenarios, a basic key/value replacement mechanism is all that is needed. The config builders in this project are designed to be such simple key/value builders.
 
 #### mode
-The basic concept of these config builders is to draw on an external source of key/value information to populate parts of the config system that are key/value in
-nature. By default, the `appSettings` and `connectionStrings` sections receive special treatment from these key/value config builders. These builders can be
-set to run in three different modes:
-  * `Strict` - This is the default. In this mode, the config builder will only operate on well-known key/value-centric configuration sections. It will enumerate each
-		key in the section, and if a matching key is found in the external source, it will replace the value in the resulting config section with the value from the
-		external source.
-  * `Greedy` - This mode is closely related to `Strict` mode, but instead of being limited to keys that already exist in the original configuration, the config builders
-		will dump all key/value pairs from the external source into the resulting config section.
-  * `Token` - This last mode operates on both the key and the value read from a config section. It can be thought of as a basic expansion of tokens in a
-		string. Any part of the key or value string that matches the pattern __`${token}`__ is a candidate for token expansion. If no corresponding value is found in the
-		external source, then the token is left alone.
+The basic concept of these config builders is to draw on an external source of key/value information to populate parts of the config system that are key/value in nature. By default, the `appSettings` and `connectionStrings` sections receive special treatment from these key/value config builders. These builders can be set to run in three different modes:
+  * `Strict` - This is the default. In this mode, the config builder will only operate on well-known key/value-centric configuration sections. It will enumerate each key in the section, and if a matching key is found in the external source, it will replace the value in the resulting config section with the value from the external source.
+  * `Greedy` - This mode is closely related to `Strict` mode, but instead of being limited to keys that already exist in the original configuration, the config builders will dump all key/value pairs from the external source into the resulting config section.
+  * `Token` - This last mode operates on both the key and the value read from a config section. It can be thought of as a basic expansion of tokens in a string. Any part of the key or value string that matches the pattern __`${token}`__ is a candidate for token expansion. If no corresponding value is found in the external source, then the token is left alone.
 
 #### prefix
-Another feature of these key/value Configuration Builders is prefix handling. Because full-framework .Net configuration is complex and nested, and external key/value
-sources are by nature quite basic and flat, leveraging key prefixes can be useful. For example, if you want to inject both App Settings and Connection Strings into
-your configuration via environment variables, you could accomplish this in two ways. Use the `EnvironmentConfigBuilder` in the default `Strict` mode and make sure you
-have the appropriate key names already coded into your config file. __OR__ you could use two `EnvironmentConfigBuilder`s in `Greedy` mode with distinct prefixes
-so they can slurp up any setting or connection string you provide without needing to update the raw config file in advance. Like this:
+Another feature of these key/value Configuration Builders is prefix handling. Because full-framework .Net configuration is complex and nested, and external key/value sources are by nature quite basic and flat, leveraging key prefixes can be useful. For example, if you want to inject both App Settings and Connection Strings into your configuration via environment variables, you could accomplish this in two ways. Use the `EnvironmentConfigBuilder` in the default `Strict` mode and make sure you have the appropriate key names already coded into your config file. __OR__ you could use two `EnvironmentConfigBuilder`s in `Greedy` mode with distinct prefixes so they can slurp up any setting or connection string you provide without needing to update the raw config file in advance. Like this:
 ```xml
 <configBuilders>
   <builders>
@@ -41,52 +41,27 @@ so they can slurp up any setting or connection string you provide without needin
 This way the same flat key/value source can be used to populate configuration for two different sections.
 
 #### stripPrefix
-A related setting that is common among all of these key/value builders is `stripPrefix`. The code above does a good job of separating app settings from connection
-strings... but now all the keys in AppSettings start with "AppSetting_". Maybe this is fine for code you wrote. Chances are that prefix is better off stripped from the
-key name before being inserted into AppSettings. `stripPrefix` is a boolean value, and accomplishes just that. It's default value is `false`.
+A related setting that is common among all of these key/value builders is `stripPrefix`. The code above does a good job of separating app settings from connection strings... but now all the keys in AppSettings start with "AppSetting_". Maybe this is fine for code you wrote. Chances are that prefix is better off stripped from the key name before being inserted into AppSettings. `stripPrefix` is a boolean value, and accomplishes just that. It's default value is `false`.
 
 #### enabled
-This is a setting that controls whether a config builder gets executed or not, and if it fails silently or not. Supported values are
-`enabled`, `disabled`, and `optional`. (As well as `true` and `false` as equivallents of enabled/disabled.) If 'enabled', then the builder will execute and throw
-exceptions when it fails. When 'disabled', builders will not execute. When set to 'optional', builders will execute but failures will be silent. This can be useful in
-cases like "User Secrets" where the backing secrets file is only likely to exist on a dev machine and not in a staging or test environment.
-The default value is `optional`, though some config builders (such as the KeyPerFile and Azure-based builders) will use `enabled`.
+This is a setting that controls whether a config builder gets executed or not, and if it fails silently or not. Supported values are `enabled`, `disabled`, and `optional`. (As well as `true` and `false` as equivallents of enabled/disabled.) If 'enabled', then the builder will execute and throw exceptions when it fails. When 'disabled', builders will not execute. When set to 'optional', builders will execute but failures will be silent. This can be useful in cases like "User Secrets" where the backing secrets file is only likely to exist on a dev machine and not in a staging or test environment. The default value is `optional`, though some config builders (such as the KeyPerFile and Azure-based builders) will use `enabled`.
 
 #### recur
-As processing of multiple configuration sections becomes entwined, the chances of [falling into a recursive cycle
-of config loading](Intro.md#recursion) increases. Especially due to the [appSettings as parameters](#appsettings-parameters) feature, 
-[this issue](#61) has a higher likelihood of striking and can be difficult to diagnose. This is where 'RecrusionGuard'
-comes in. It will try to keep track of config sections that are being processed to detect any
-potential loops. When a loop is detected, it can either _throw_ an exception to call attention to the bad
-configuration, or it can _stop_ the loop and silently unwind, or it can do nothing and _allow_ the loop
-to continue. The latter two options is not recommended as it
-may result in non-deterministic results and overflows. Options for this setting are `Throw`, `Stop`, or `Allow`. The default is `Throw`.
+As processing of multiple configuration sections becomes entwined, the chances of [falling into a recursive cycle of config loading](Intro.md#recursion) increases. Especially due to the [appSettings as parameters](#appsettings-parameters) feature, [this issue](#61) has a higher likelihood of striking and can be difficult to diagnose. This is where 'RecrusionGuard' comes in. It will try to keep track of config sections that are being processed to detect any potential loops. When a loop is detected, it can either _throw_ an exception to call attention to the bad configuration, or it can _stop_ the loop and silently unwind, or it can do nothing and _allow_ the loop to continue. The latter two options is not recommended as it may result in non-deterministic results and overflows. Options for this setting are `Throw`, `Stop`, or `Allow`. The default is `Throw`.
 
 #### charMap
-This is a setting that defines which characters from a config key need to be replaced with which alternate characters
-when querying for a value in a particular config source. This feature actually maps strings, and is not restricted to
-single character replacement. The format for charMap parameter is a comma-separated list of `string=string`. To include
-comma or equals in your mappings, you can escape them by doubling. The base default value is to not map any characters, but a
-number of builders such as the Environment and Azure builders do populate this mapping by default.
+This is a setting that defines which characters from a config key need to be replaced with which alternate characters when querying for a value in a particular config source. This feature actually maps strings, and is not restricted to single character replacement. The format for charMap parameter is a comma-separated list of `string=string`. To include comma or equals in your mappings, you can escape them by doubling. The base default value is to not map any characters, but a number of builders such as the Environment and Azure builders do populate this mapping by default.
 
 #### escapeExpandedValues
-Somewhat of a remnant from earlier versions that allowed operating on raw XML, this flag can be used to specify
-whether or not to XML-escape values when replacing tokens in 'Token' mode. The default value is `false`.
+Somewhat of a remnant from earlier versions that allowed operating on raw XML, this flag can be used to specify whether or not to XML-escape values when replacing tokens in 'Token' mode. The default value is `false`.
 
 #### tokenPattern
-This is a setting that is shared between all KeyValueConfigBuilder-derived builders is `tokenPattern`. When describing the `Expand` behavior of these builders
-above, it was mentioned that the raw xml is searched for tokens that look like __`${token}`__. This is done with a regular expression. `@"\$\{(\w+)\}"` to be exact.
-The set of characters that matches `\w` is more strict than xml and many sources of config values allow, and some applications may need to allow more exotic characters
-in their token names. Additionally there might be scenarios where the `${}` pattern is not acceptable.
+This is a setting that is shared between all KeyValueConfigBuilder-derived builders is `tokenPattern`. When describing the `Expand` behavior of these builders above, it was mentioned that the raw xml is searched for tokens that look like __`${token}`__. This is done with a regular expression. `@"\$\{(\w+)\}"` to be exact. The set of characters that matches `\w` is more strict than xml and many sources of config values allow, and some applications may need to allow more exotic characters in their token names. Additionally there might be scenarios where the `${}` pattern is not acceptable.
 
-`tokenPattern` allows developers to change the regex that is used for token matching. It is a string argument, and no validation is done to make sure it is
-a well-formed non-dangerous regex - so use it wisely. The only real restriction is that is must contain a capture group. The entire regex must match the entire token,
-and the first capture must be the token name to look up in the config source.
+`tokenPattern` allows developers to change the regex that is used for token matching. It is a string argument, and no validation is done to make sure it is a well-formed non-dangerous regex - so use it wisely. The only real restriction is that is must contain a capture group. The entire regex must match the entire token, and the first capture must be the token name to look up in the config source.
 
-#### AppSettings Parameters
-Starting with version 2, initialization parameters for key/value config builders can be drawn from `appSettings` instead of being hard-coded in the
-config file. This should allow for greater flexibility when deploying solutions with config builders where connection strings need to be kept secure,
-or deployment environments are swappable. Eg:
+## AppSettings Parameters
+Starting with version 2, initialization parameters for key/value config builders can be drawn from `appSettings` instead of being hard-coded in the config file. This should allow for greater flexibility when deploying solutions with config builders where connection strings need to be kept secure, or deployment environments are swappable. Eg:
 
 ```xml
 <configBuilders>
@@ -102,24 +77,15 @@ or deployment environments are swappable. Eg:
 </appSettings>
 ```
 
-The way this feature works is that instead of directly reading an initialization parameter, each `KeyValueConfigBuilder` class has the option to run it through
-`UpdateConfigSettingWithAppSettings(string)` the first time they read it. If this happens, the parameter value will go through a token-replacement that reads from
-`appSettings` and return the updated value. This updated value is also kept in the underlying 'config' dictionary, so subsequent direct reads will get the updated
-value as well. (For config builders taking advantage of this feature, note that this method only works *after* base lazy initialization has started. Be sure to call
-`base.LazyInitialize()` before using this method.)
+The way this feature works is that instead of directly reading an initialization parameter, each `KeyValueConfigBuilder` class has the option to run it through `UpdateConfigSettingWithAppSettings(string)` the first time they read it. If this happens, the parameter value will go through a token-replacement that reads from `appSettings` and return the updated value. This updated value is also kept in the underlying 'config' dictionary, so subsequent direct reads will get the updated value as well. (For config builders taking advantage of this feature, note that this method only works *after* base lazy initialization has started. Be sure to call `base.LazyInitialize()` before using this method.)
 
-Because this feature is somewhat recursive (afterall, it is reading configuration values for builders - that are used to build configuration sections - from a
-configuration section) there are limitations when using this feature on the `appSettings` section itself. If a builder is currently processing the `appSettings` section
-when using this feature, then the feature is still enabled - __but__ it can only draw on values that were hard-coded, or inserted into `appSettings` by config builders that
-execute before it in the builder chain.
+Because this feature is somewhat recursive (afterall, it is reading configuration values for builders - that are used to build configuration sections - from a configuration section) there are limitations when using this feature on the `appSettings` section itself. If a builder is currently processing the `appSettings` section when using this feature, then the feature is still enabled - __but__ it can only draw on values that were hard-coded, or inserted into `appSettings` by config builders that execute before it in the builder chain.
 
-Although most initialization parameters can take advantage of this flexibility, it might not always make sense to apply this technique to all parameters. Of the
-base parameters defined for all key/value config builders, `tokenPrefix` stands out as the common setting that *does not allow* reading from `appSettings`. 
+Although most initialization parameters can take advantage of this flexibility, it might not always make sense to apply this technique to all parameters. Of the base parameters defined for all key/value config builders, `tokenPrefix` stands out as the common setting that *does not allow* reading from `appSettings`. 
 
 
 ## Config Builders In This Project
-*Note about following codeboxes: Parameters inside `[]`s are optional. Parameters grouped in `()`s are mutually exclusive. Parameters beginning with `@` allow appSettings substitution. The first line of parameters are common to all builders and optional. Their meaning and use are [documented above](#keyvalue-config-builders) and they are grouped on one line for brevity.
-Whenever a builder has a different default value for a given parameter, the differing default is also listed.
+*Note about following codeboxes: Parameters inside `[]`s are optional. Parameters grouped in `()`s are mutually exclusive. Parameters beginning with `@` allow appSettings substitution. The first line of parameters are common to all builders and optional. Their meaning and use are [documented above](#introduction-to-keyvalue-config-builders) and they are grouped on one line for brevity. Whenever a builder has a different default value for a given parameter, the differing default is also listed.
 
 ### EnvironmentConfigBuilder
 ```xml
@@ -128,11 +94,7 @@ Whenever a builder has a different default value for a given parameter, the diff
     type="Microsoft.Configuration.ConfigurationBuilders.EnvironmentConfigBuilder, Microsoft.Configuration.ConfigurationBuilders.Environment" />
 ```
 This is the most basic of the config builders. It draws its values from Environment, and it does not have any additional configuration options.
-  * __NOTE:__ In a Windows container environment, variables set at run time are only injected into the EntryPoint process environment. 
-  Applications that run as a service or a non-EntryPoint process will not pick up these variables unless they are otherwise injected through
-  some mechanism in the container. For [IIS](https://github.com/Microsoft/iis-docker/pull/41)/[ASP.Net](https://github.com/Microsoft/aspnet-docker)-based
-  containers, the current version of [ServiceMonitor.exe](https://github.com/Microsoft/iis-docker/pull/41) handles this in the *DefaultAppPool*
-  only. Other Windows-based container variants may need to develop their own injection mechanism for non-EntryPoint processes.
+  * __NOTE:__ In a Windows container environment, variables set at run time are only injected into the EntryPoint process environment. Applications that run as a service or a non-EntryPoint process will not pick up these variables unless they are otherwise injected through some mechanism in the container. For [IIS](https://github.com/Microsoft/iis-docker/pull/41)/[ASP.Net](https://github.com/Microsoft/aspnet-docker)-based containers, the current version of [ServiceMonitor.exe](https://github.com/Microsoft/iis-docker/pull/41) handles this in the *DefaultAppPool* only. Other Windows-based container variants may need to develop their own injection mechanism for non-EntryPoint processes.
 
 ### UserSecretsConfigBuilder
 ```xml
@@ -141,25 +103,13 @@ This is the most basic of the config builders. It draws its values from Environm
     (@userSecretsId="12345678-90AB-CDEF-1234-567890" | @userSecretsFile="~\secrets.file")
     type="Microsoft.Configuration.ConfigurationBuilders.UserSecretsConfigBuilder, Microsoft.Configuration.ConfigurationBuilders.UserSecrets" />
 ```
-To enable a feature similar to .Net Core's user secrets you can use this config builder. Microsoft is adding better secrets management in future releases
-of Visual Studio, and this config builder will be a part of that plan. Web Applications are the initial target for this work in Visual Studio, but this
-configuration builder can be used in any full-framework project if you specify your own secrets file. (Or define the 'UserSecretsId' property in your
-project file and create the raw secrets file in the correct location for reading.) In order to keep external dependencies out of the picture, the
-actual secret file will be xml formatted - though this should be considered an implementation detail, and the format should not be relied upon.
-(If you need to share a secrets.json file with Core projects, you could consider using the `SimpleJsonConfigBuilder` below... but as with this
-builder, the json format for Core secrets is technically an implementation detail subject to change as well.)
+To enable a feature similar to .Net Core's user secrets you can use this config builder. Microsoft is adding better secrets management in future releases of Visual Studio, and this config builder will be a part of that plan. Web Applications are the initial target for this work in Visual Studio, but this configuration builder can be used in any full-framework project if you specify your own secrets file. (Or define the 'UserSecretsId' property in your project file and create the raw secrets file in the correct location for reading.) In order to keep external dependencies out of the picture, the actual secret file will be xml formatted - though this should be considered an implementation detail, and the format should not be relied upon. (If you need to share a secrets.json file with Core projects, you could consider using the `SimpleJsonConfigBuilder` below... but as with this builder, the json format for Core secrets is technically an implementation detail subject to change as well.)
 
 There are two additional configuration attributes for this config builder:
-  * `userSecretsId` - This is the preferred method for identifying an xml secrets file. It works similar to .Net Core, which uses a 'UserSecretsId' project
-  property to store this identifier. (The string does not have to be a Guid. Just unique. The VS "Manage User Secrets" experience produces a Guid.) With this
-  attribute, the `UserSecretsConfigBuilder` will look in a well-known local location (%APPDATA%\Microsoft\UserSecrets\\&lt;userSecretsId&gt;\secrets.xml in
-  Windows environments) for a secrets file belonging to this identifier.
-  * `userSecretsFile` - An optional attribute specifying the file containing the secrets. The '~' character can be used at the start to reference the app root.
-  One of this attribute or the 'userSecretsId' attribute is required. If both are specified, 'userSecretsFile' takes precedence.
+  * `userSecretsId` - This is the preferred method for identifying an xml secrets file. It works similar to .Net Core, which uses a 'UserSecretsId' project property to store this identifier. (The string does not have to be a Guid. Just unique. The VS "Manage User Secrets" experience produces a Guid.) With this attribute, the `UserSecretsConfigBuilder` will look in a well-known local location (%APPDATA%\Microsoft\UserSecrets\\&lt;userSecretsId&gt;\secrets.xml in Windows environments) for a secrets file belonging to this identifier.
+  * `userSecretsFile` - An optional attribute specifying the file containing the secrets. The '~' character can be used at the start to reference the app root. One of this attribute or the 'userSecretsId' attribute is required. If both are specified, 'userSecretsFile' takes precedence.
 
-The next Visual Studio update will include "Manage User Secrets..." support for WebForms projects. When using this feature, Visual Studio will create an
-empty secrets file outside of the solution folder and allow editing the raw content to add/remove secrets. This is similar to the .Net Core experience,
-and currently exposes the format of the file which, as mentioned above, should be considered an implementation detail. A non-empty secrets file would look like this:
+The next Visual Studio update will include "Manage User Secrets..." support for WebForms projects. When using this feature, Visual Studio will create an empty secrets file outside of the solution folder and allow editing the raw content to add/remove secrets. This is similar to the .Net Core experience, and currently exposes the format of the file which, as mentioned above, should be considered an implementation detail. A non-empty secrets file would look like this:
 
 ```xml
 <?xml version="1.0" encoding="utf-8" ?>
@@ -171,29 +121,15 @@ and currently exposes the format of the file which, as mentioned above, should b
 ```
 
 ### Azure Config Builders
-This repo contains two different configuration builders that draw from two different Azure stores: Key Vault and App Configuration.
-These stores have differences and were developed to accommodate different usage scenarios. But they both draw on some similar
-capabilities from the Azure SDK - Authentication in particular.
+This repo contains two different configuration builders that draw from two different Azure stores: Key Vault and App Configuration. These stores have differences and were developed to accommodate different usage scenarios. But they both draw on some similar capabilities from the Azure SDK - Authentication in particular.
 
-Both builders make use of [`DefaultAzureCredential`](https://docs.microsoft.com/en-us/dotnet/api/azure.identity.defaultazurecredential)
-for connecting to their respective service. This is a powerful yet easy-to-use method for connecting to Azure services and it provides
-these builders with quite a bit of flexibility. `DefaultAzureCredential` searches through a list of different types of Azure credential
-sources until it finds one to use, which gives applications that use these providers quite a few options. For **User-Assigned Managed
-Identity**, or **Client Certificate-based** authorization, applications can take advantage of the abilities of [`EnvironmentalCredential`](https://docs.microsoft.com/en-us/dotnet/api/azure.identity.environmentcredential)
-to read the necessary options for these methods via environment variables. Builders who require more complexity in the selection of
-their Azure credential for these builders can extend and override the `GetCredential()` method of either builder to supply the correct
-`TokenCredential` for connecting to Azure.
+Both builders make use of [`DefaultAzureCredential`](https://docs.microsoft.com/en-us/dotnet/api/azure.identity.defaultazurecredential) for connecting to their respective service. This is a powerful yet easy-to-use method for connecting to Azure services and it provides these builders with quite a bit of flexibility. `DefaultAzureCredential` searches through a list of different types of Azure credential sources until it finds one to use, which gives applications that use these providers quite a few options. For **User-Assigned Managed Identity**, or **Client Certificate-based** authorization, applications can take advantage of the abilities of [`EnvironmentalCredential`](https://docs.microsoft.com/en-us/dotnet/api/azure.identity.environmentcredential) to read the necessary options for these methods via environment variables. Builders who require more complexity in the selection of their Azure credential for these builders can extend and override the `GetCredential()` method of either builder to supply the correct `TokenCredential` for connecting to Azure.
 
-In a similar vein to `GetCredential()`, builders who need finer control over the way it connects to Azure, the `GetConfigurationClientOptions()`
-and `GetSecretClientOptions()` virtual methods have been added to the Azure config builders to support special scenarios. (For
-example, connecting to Azure through a proxy.)
+In a similar vein to `GetCredential()`, builders who need finer control over the way it connects to Azure, the `GetConfigurationClientOptions()` and `GetSecretClientOptions()` virtual methods have been added to the Azure config builders to support special scenarios. (For example, connecting to Azure through a proxy.)
 
-NOTE: These packages both currently depend on version ***1.2*** of the `Azure.Identity` nuget package. This version was chosen because
-it has a fairly comprehensive list of capabilities for `DefaultAzureCredential` but also is a relatively early version of this SDK package.
-This way these builders won't be responsible for forcing unwanted package upgrades when not necessary. However, `DefaultAzureCredential`
-[frequently picks up new capabilies](https://github.com/Azure/azure-sdk-for-net/blob/main/sdk/identity/Azure.Identity/CHANGELOG.md), and
-users are encouraged to manually update the version of `Azure.Identity` their application uses if they want to take advantage of new
-features.
+>:information_source: [NOTE]
+>
+> These packages both currently depend on version ***1.2*** of the `Azure.Identity` nuget package. This version was chosen because it has a fairly comprehensive list of capabilities for `DefaultAzureCredential` but also is a relatively early version of this SDK package. This way these builders won't be responsible for forcing unwanted package upgrades when not necessary. However, `DefaultAzureCredential` [frequently picks up new capabilies](https://github.com/Azure/azure-sdk-for-net/blob/main/sdk/identity/Azure.Identity/CHANGELOG.md), and users are encouraged to manually update the version of `Azure.Identity` their application uses if they want to take advantage of new features.
 
 #### AzureAppConfigurationBuilder
 ```xml
@@ -208,23 +144,15 @@ features.
 ```
 >:information_source: [NOTE]
 >
->When connecting to an Azure App Configuration store, the identity that is being used must be assigned either the `Azure App Configuration Data Reader` role or the `Azure App Configuration Data Owner` role. Otherwise the config builder will encounter a "403 Forbidden" response from Azure and throw an exception if not `optional`.
+> When connecting to an Azure App Configuration store, the identity that is being used must be assigned either the `Azure App Configuration Data Reader` role or the `Azure App Configuration Data Owner` role. Otherwise the config builder will encounter a "403 Forbidden" response from Azure and throw an exception if not `optional`.
 
-[AppConfiguration](https://docs.microsoft.com/en-us/azure/azure-app-configuration/overview) is a new offering from Azure. If you
-wish to use this new service for managing your configuration, then use this AzureAppConfigurationBuilder. Either `endpoint` or `connectionString` are
-required, but all other attributes are optional. If both `endpoint` and `connectionString` are used, then preference is given to the connection string.
+[AppConfiguration](https://docs.microsoft.com/en-us/azure/azure-app-configuration/overview) is a new offering from Azure. If you wish to use this new service for managing your configuration, then use this AzureAppConfigurationBuilder. Either `endpoint` or `connectionString` are required, but all other attributes are optional. If both `endpoint` and `connectionString` are used, then preference is given to the connection string.
   * `endpoint` - This specifies the AppConfiguration store to connect to.
-  * ~~`connectionString`~~ - The recommendation is to use `endpoint` in conjunction with [DefaultAzureCredential](#azure-config-builders). ~~This specifies
-    the AppConfiguration store to connect to, along with the Id and Secret necessary to access the service. Be careful
-	not to expose any secrets in your code, repos, or App Configuration stores if you use this method for connecting.~~
+  * ~~`connectionString`~~ - The recommendation is to use `endpoint` in conjunction with [DefaultAzureCredential](#azure-config-builders). ~~This specifies the AppConfiguration store to connect to, along with the Id and Secret necessary to access the service. Be careful not to expose any secrets in your code, repos, or App Configuration stores if you use this method for connecting.~~
   * `keyFilter` - Use this to select a set of configuration values matching a certain key pattern.
   * `labelFilter` - Only retrieve configuration values that match a certain label.
-  * `acceptDateTime` - Instead of versioning ala Azure Key Vault, AppConfiguration uses timestamps. Use this attribute to go back in time
-  to retrieve configuration values from a past state.
-  * `useAzureKeyVault` - Enable this feature to allow AzureAppConfigurationBuilder to connect to and retrieve secrets from Azure Key Vault for
-  config values that are stored in Key Vault. The same managed service identity that is used for connecting to the AppConfiguration service will
-  be used to connect to Key Vault. The Key Vault uri is retrieved as part of the data from AppConfiguration and does not need to be specified here.
-  Default is `false`.
+  * `acceptDateTime` - Instead of versioning ala Azure Key Vault, AppConfiguration uses timestamps. Use this attribute to go back in time to retrieve configuration values from a past state.
+  * `useAzureKeyVault` - Enable this feature to allow AzureAppConfigurationBuilder to connect to and retrieve secrets from Azure Key Vault for config values that are stored in Key Vault. The same managed service identity that is used for connecting to the AppConfiguration service will be used to connect to Key Vault. The Key Vault uri is retrieved as part of the data from AppConfiguration and does not need to be specified here. Default is `false`.
 
 #### AzureKeyVaultConfigBuilder
 ```xml
@@ -235,34 +163,22 @@ required, but all other attributes are optional. If both `endpoint` and `connect
     [@preloadSecretNames="true"]
     type="Microsoft.Configuration.ConfigurationBuilders.AzureKeyVaultConfigBuilder, Microsoft.Configuration.ConfigurationBuilders.Azure" />
 ```
-If your secrets are kept in Azure Key Vault, then this config builder is for you. There are four additional attributes for this config builder. The `vaultName`
-attribute (or `uri`) is required. Previous iterations of this config builder allowed for a `connectionString` as a way to supply credential information for connecting to
-Azure Key Vault. This method is no longer allowed as it is not a supported scenario for the current `Azure.Identity` SDK which is used for connecting
-to Azure services. Instead, this iteration of the config builder exclusively uses [DefaultAzureCredential](https://docs.microsoft.com/en-us/dotnet/api/azure.identity.defaultazurecredential)
-from the `Azure.Identity` package to handle credentials for connecting to Azure Key Vault.
+If your secrets are kept in Azure Key Vault, then this config builder is for you. There are four additional attributes for this config builder. The `vaultName` attribute (or `uri`) is required. Previous iterations of this config builder allowed for a `connectionString` as a way to supply credential information for connecting to Azure Key Vault. This method is no longer allowed as it is not a supported scenario for the current `Azure.Identity` SDK which is used for connecting to Azure services. Instead, this iteration of the config builder exclusively uses [DefaultAzureCredential](https://docs.microsoft.com/en-us/dotnet/api/azure.identity.defaultazurecredential) from the `Azure.Identity` package to handle credentials for connecting to Azure Key Vault.
   * `vaultName` - This (or `uri`) is a required attribute. It specifies the name of the vault in your Azure subscription from which to read key/value pairs.
-  * `uri` - Connect to non-Azure Key Vault providers with this attribute. If not specified, Azure is the assumed Vault provider. If the uri _is_ specified, then `vaultName` is no longer a required parameter.
+  * `uri` - Connect to non-Azure Key Vault providers with this attribute. If not specified, Azure is the assumed Vault provider. If the uri _is_ specified, then vaultName` is no longer a required parameter.
   * `version` - Azure Key Vault provides a versioning feature for secrets. If this is specified, the builder will only retrieve secrets matching this version.
-  * `preloadSecretNames` - By default, this builder will query __all__ the key names in the key vault when it is initialized to improve performance. If this is
-  a concern, set this attribute to 'false', and secrets will be retrieved one at a time. This could also be useful if the vault allows "Get" access but not
-  "List" access. (NOTE: Disabling preload is incompatible with Greedy mode.)
+  * `preloadSecretNames` - By default, this builder will query __all__ the key names in the key vault when it is initialized to improve performance. If this is a concern, set this attribute to 'false', and secrets will be retrieved one at a time. This could also be useful if the vault allows "Get" access but not "List" access. (NOTE: Disabling preload is incompatible with Greedy mode.)
 
-__Tip:__ Azure Key Vault uses random per-secret Guid assignments for versioning, which makes specifying a secret `version` tag on this builder rather
-limiting, as it will only ever update one config value. To make version handling more useful, V2 of this builder takes advantage of the new key-updating
-feature to allow users to specify version tags in key names rather than on the config builder declaration. That way, the same builder can handle multiple
-keys with specific versions instead of needing to redefine multiple builders.
-When requesting a specific version for a particular key, the key name in the original config file should look like __`keyName/versionId`__. The
-AzureKeyVaultConfigBuilder will only substitue values for 'keyName' if the specified 'versionId' exists in the vault. When that happens, the
-AzureKeyVaultConfigBuilder will remove the `/versionId` from the original key, and the resulting config section will only contain `keyName`.
-For example:
-```xml
-<appSettings configBuilders="AzureKeyVault">
-  <add key="item1" value="Replaced with latest value from the key vault." />
-  <add key="item2/0123456789abcdefdeadbeefbadf00d" value="Replaced with specific version only." />
-</appSettings>
-```
-Assuming both of these items exist in the vault, and the version tag for `item2` is valid, this would result in an collection of appSettings with two
-entries: `item1` and `item2`.
+>:information_source: [NOTE]
+>
+> Azure Key Vault uses random per-secret Guid assignments for versioning, which makes specifying a secret `version` tag on this builder rather limiting, as it will only ever update one config value. To make version handling more useful, V2 of this builder takes advantage of the new key-updating feature to allow users to specify version tags in key names rather than on the config builder declaration. That way, the same builder can handle multiple keys with specific versions instead of needing to redefine multiple builders. When requesting a specific version for a particular key, the key name in the original config file should look like __`keyName/versionId`__. The AzureKeyVaultConfigBuilder will only substitue values for 'keyName' if the specified 'versionId' exists in the vault. When that happens, the AzureKeyVaultConfigBuilder will remove the `/versionId` from the original key, and the resulting config section will only contain `keyName`. For example:
+> ```xml
+> <appSettings configBuilders="AzureKeyVault">
+>   <add key="item1" value="Replaced with latest value from the key vault." />
+>   <add key="item2/0123456789abcdefdeadbeefbadf00d" value="Replaced with specific version only." />
+> </appSettings>
+> ```
+> Assuming both of these items exist in the vault, and the version tag for `item2` is valid, this would result in an collection of appSettings with two entries: `item1` and `item2`.
 
 ### KeyPerFileConfigBuilder
 ```xml
@@ -273,14 +189,10 @@ entries: `item1` and `item2`.
     [keyDelimiter=":"]
     type="Microsoft.Configuration.ConfigurationBuilders.KeyPerFileConfigBuilder, Microsoft.Configuration.ConfigurationBuilders.KeyPerFile" />
 ```
-This config builder uses a directory's files as a source of values. A file's name is the key, and the contents are the value. This
-config builder can be useful when running in an orchestrated container environment, as systems like Docker Swarm and Kubernetes provide 'secrets' to
-their orchestrated windows containers in this key-per-file manner.
-  * `directoryPath` - This is a required attribute. It specifies a path to the source directory to look in for values. Docker for Windows secrets
-  are stored in the 'C:\ProgramData\Docker\secrets' directory by default.
+This config builder uses a directory's files as a source of values. A file's name is the key, and the contents are the value. This config builder can be useful when running in an orchestrated container environment, as systems like Docker Swarm and Kubernetes provide 'secrets' to their orchestrated windows containers in this key-per-file manner.
+  * `directoryPath` - This is a required attribute. It specifies a path to the source directory to look in for values. Docker for Windows secrets are stored in the 'C:\ProgramData\Docker\secrets' directory by default.
   * `ignorePrefix` - Files that start with this prefix will be excluded. Defaults to "ignore.".
-  * `keyDelimiter` - If specified, the config builder will traverse multiple levels of the directory, building key names up with this delimeter. If
-  this value is left `null` however, the config builder only looks at the top-level of the directory. `null` is the default.
+  * `keyDelimiter` - If specified, the config builder will traverse multiple levels of the directory, building key names up with this delimeter. If this value is left `null` however, the config builder only looks at the top-level of the directory. `null` is the default.
 
 ### SimpleJsonConfigBuilder
 ```xml
@@ -290,20 +202,14 @@ their orchestrated windows containers in this key-per-file manner.
     [@jsonMode="(Flat*|Sectional)"]
     type="Microsoft.Configuration.ConfigurationBuilders.SimpleJsonConfigBuilder, Microsoft.Configuration.ConfigurationBuilders.Json" />
 ```
-Because .Net Core projects can rely heavily on json files for configuration, it makes some sense to allow those same files to be used in full-framework
-configuration as well. You can imagine that the heirarchical nature of json might enable some fantastic capabilities for building complex configuration sections.
-But this config builder is meant to be just a simple mapping from a flat key/value source into specific key/value areas of full-framework configuration. Thus its name
-begins with 'Simple.' Think of the backing json file as a basic dictionary, rather than a complex heirarchical object.
+Because .Net Core projects can rely heavily on json files for configuration, it makes some sense to allow those same files to be used in full-framework configuration as well. You can imagine that the heirarchical nature of json might enable some fantastic capabilities for building complex configuration sections. But this config builder is meant to be just a simple mapping from a flat key/value source into specific key/value areas of full-framework configuration. Thus its name begins with 'Simple.' Think of the backing json file as a basic dictionary, rather than a complex heirarchical object.
 
 (A multi-level heirarchical file can be used. This provider will simply 'flatten' the depth by appending the property name at each level using ':' as a delimiter.)
 
 There are two additional attributes that can be used to configure this builder:
   * `jsonFile` - A required attribute specifying the json file to draw from. The '~' character can be used at the start to reference the app root.
   * `jsonMode` - `[Flat|Sectional]`. 'Flat' is the default.
-    - This attribute requires a little more explanation. It says above to think of the json file as a single flat key/value source. This is the usual that applies to
-    other key/value config builders like `EnvironmentConfigBuilder` and `AzureKeyVaultConfigBuilder` because those sources provide no other option. If the
-    `SimpleJsonConfigBuilder` is configured in 'Sectional' mode, then the json file is conceptually divided - at the top level only - into multiple simple dictionaries.
-    Each one of those dictionaries will only be applied to the config section that matches the top-level property name attached to them. For example:
+    - This attribute requires a little more explanation. It says above to think of the json file as a single flat key/value source. This is the usual that applies to other key/value config builders like `EnvironmentConfigBuilder` and `AzureKeyVaultConfigBuilder` because those sources provide no other option. If the `SimpleJsonConfigBuilder` is configured in 'Sectional' mode, then the json file is conceptually divided - at the top level only - into multiple simple dictionaries. Each one of those dictionaries will only be applied to the config section that matches the top-level property name attached to them. For example:
 ```json
     {
         "appSettings" : {

--- a/docs/SectionHandlers.md
+++ b/docs/SectionHandlers.md
@@ -1,16 +1,9 @@
 # Section Handlers
-*KeyValueConfigBuilders* are designed to operate on any config section that has a basic key/value structure. If that statement
-sounds somewhat vague, it probably because it is. These builders have been intentionally designed around a key/value-lookup
-paradigm. So, as the old saying goes, when all you have is a hammer, everything looks like a nail.
+*KeyValueConfigBuilders* are designed to operate on any config section that has a basic key/value structure. If that statement sounds somewhat vague, it probably because it is. These builders have been intentionally designed around a key/value-lookup paradigm. So, as the old saying goes, when all you have is a hammer, everything looks like a nail.
 
-Magically, the `<appSettings>` and `<connectionStrings>` look like key/value config sections, so these builders can all be
-applied there. Of course it's not really magic. Those are the two most commonly used and obvious key/value-like config sections out
-there. So we have wired them up to work right out of the box. But developers can wire up additional sections by registering a
-new `SectionHandler<T>` for each type of section they want to process with a `KeyValueConfigBuilder`.
+Magically, the `<appSettings>` and `<connectionStrings>` look like key/value config sections, so these builders can all be applied there. Of course it's not really magic. Those are the two most commonly used and obvious key/value-like config sections out there. So we have wired them up to work right out of the box. But developers can wire up additional sections by registering a new `SectionHandler<T>` for each type of section they want to process with a `KeyValueConfigBuilder`.
 
-A `SectionHandler<T>` is the interface that these config builders use to interact with different configuration sections. That way
-builders only need to know how to work with `SectionHandler<T>` and not have custom code to handle each different type of config
-section it might be applied to. To implement a new section handler, there are only two required methods\*:
+A `SectionHandler<T>` is the interface that these config builders use to interact with different configuration sections. That way builders only need to know how to work with `SectionHandler<T>` and not have custom code to handle each different type of config section it might be applied to. To implement a new section handler, there are only two required methods\*:
 ```CSharp
 public class MySpecialSectionHandler : SectionHandler<MySpecialSection>
 {
@@ -30,31 +23,15 @@ public class MySpecialSectionHandler : SectionHandler<MySpecialSection>
     //public override IEnumerator<KeyValuePair<string, object>> GetEnumerator() { /* key, state */ }
 }
 ```
-Keep in mind when implementing a section handler, that `InsertOrUpdate()` will be called while iterating over the enumerator
-supplied by `GetEnumerator()`. So the two methods must work in cooperation to make sure that the enumerator does not get confused
-while iterating. Ie, don't tamper with the collection that the enumerator is iterating over. Make a copy of the collection first
-and iterate over that if necessary.
+Keep in mind when implementing a section handler, that `InsertOrUpdate()` will be called while iterating over the enumerator supplied by `GetEnumerator()`. So the two methods must work in cooperation to make sure that the enumerator does not get confused while iterating. Ie, don't tamper with the collection that the enumerator is iterating over. Make a copy of the collection first and iterate over that if necessary.
 
-A section handler is free to interpret the structure of a `ConfigurationSection` in any way it sees fit, so long it can be exposed as an
-enumerable list of key/value things. It can even handle situations where the each configuration record contains more than just a
-single key/value pair. Consider the implementation of `ConnectionStringsSectionHandler` - it uses the `ConnectionStringSettings` instance
-itself as the "state" of the tuple, so in 'InsertOrUpdate()' it can simply update the old connection string instance, (thereby preserving
-other existing properties like 'ProviderName') instead of creating a new one from scratch.
+A section handler is free to interpret the structure of a `ConfigurationSection` in any way it sees fit, so long it can be exposed as an enumerable list of key/value things. It can even handle situations where the each configuration record contains more than just a single key/value pair. Consider the implementation of `ConnectionStringsSectionHandler` - it uses the `ConnectionStringSettings` instance itself as the "state" of the tuple, so in 'InsertOrUpdate()' it can simply update the old connection string instance, (thereby preserving other existing properties like 'ProviderName') instead of creating a new one from scratch.
 
-New section handlers are be introduced to the config system the same way config builders are... via config. Section handlers follow
-along with the old provider model introduced in .Net 2.0, so they require `name` and `type` attributes, but can additionally support
-any other attribute needed by passing them in a `NameValueCollection` to the `Initialize(name, config)` method.
+New section handlers are be introduced to the config system the same way config builders are... via config. Section handlers follow along with the old provider model introduced in .Net 2.0, so they require `name` and `type` attributes, but can additionally support any other attribute needed by passing them in a `NameValueCollection` to the `Initialize(name, config)` method.
 
-Section handlers also have an optional virtual method `TryGetOriginalCase(string)` that attempts to preserve casing in config files
-when executing in `Greedy` mode. When operating in `Strict` mode, config builders in this repo have always preserved the case of the
-key when updating the value. This was easy because the original key was already at hand during lookup and replacement. In `Greedy`
-mode however, the original key from the config file was not used since it was not needed for a one-item lookup. Thus any greedy substitutions
-had their keys replaced with the keys from the external config source. Functionally they should be the same, since key/value config
-is supposed to be case-insensitive. But aesthetically, being a good citizen and not replacing the original key case is good.
+Section handlers also have an optional virtual method `TryGetOriginalCase(string)` that attempts to preserve casing in config files when executing in `Greedy` mode. When operating in `Strict` mode, config builders in this repo have always preserved the case of the key when updating the value. This was easy because the original key was already at hand during lookup and replacement. In `Greedy` mode however, the original key from the config file was not used since it was not needed for a one-item lookup. Thus any greedy substitutions had their keys replaced with the keys from the external config source. Functionally they should be the same, since key/value config is supposed to be case-insensitive. But aesthetically, being a good citizen and not replacing the original key case is good.
 
-The `AppSettingsSectionHandler` and `ConnectionStringsSectionHandler`
-are implicitly added at the root level config, but they can be clear/removed just like any other item in an add/remove/clear configuration
-collection. As an example, here is what their explicit declaration would look like:
+The `AppSettingsSectionHandler` and `ConnectionStringsSectionHandler` are implicitly added at the root level config, but they can be clear/removed just like any other item in an add/remove/clear configuration collection. As an example, here is what their explicit declaration would look like:
 ```xml
 <configSections>
   <section name="Microsoft.Configuration.ConfigurationBuilders.SectionHandlers" type="Microsoft.Configuration.ConfigurationBuilders.SectionHandlersSection, Microsoft.Configuration.ConfigurationBuilders.Base" restartOnExternalChanges="false" requirePermission="false" />
@@ -67,11 +44,7 @@ collection. As an example, here is what their explicit declaration would look li
   </handlers>
 </Microsoft.Configuration.ConfigurationBuilders.SectionHandlers>
 ```
-When adding additional handlers, the name of this section must be 'Microsoft.Configuration.ConfigurationBuilders.SectionHandlers' so key/value config builders can find it.
-Also note that a more qualified type name may be required so the runtime can determine which assembly contains the new handler type. When working
-with ASP.Net applications, it is hit and miss regarding whether its possible to define new section handlers in `App_Code` or not. Some configuration
-sections (such as `appSettings`) get loaded by ASP.Net before `App_Code` is compiled, so handlers for those sections will need to be
-compiled in a separate assembly in the 'bin' directory. For example:
+When adding additional handlers, the name of this section must be 'Microsoft.Configuration.ConfigurationBuilders.SectionHandlers' so key/value config builders can find it. Also note that a more qualified type name may be required so the runtime can determine which assembly contains the new handler type. When working with ASP.Net applications, it is hit and miss regarding whether its possible to define new section handlers in `App_Code` or not. Some configuration sections (such as `appSettings`) get loaded by ASP.Net before `App_Code` is compiled, so handlers for those sections will need to be compiled in a separate assembly in the 'bin' directory. For example:
 ```xml
 <configSections>
   <section name="Microsoft.Configuration.ConfigurationBuilders.SectionHandlers" type="Microsoft.Configuration.ConfigurationBuilders.SectionHandlersSection, Microsoft.Configuration.ConfigurationBuilders.Base" restartOnExternalChanges="false" requirePermission="false" />
@@ -88,14 +61,9 @@ compiled in a separate assembly in the 'bin' directory. For example:
 ```
 
 ## ConnectionStringsSectionHandler2
-Version 3 of this package suite includes a new section handler for the `<connectionStrings>` section. For maximum compatibility, the
-old section handler is still used by default. Here we will explain how to use this new section handler and how to replace the old one.
+Version 3 of this package suite includes a new section handler for the `<connectionStrings>` section. For maximum compatibility, the old section handler is still used by default. Here we will explain how to use this new section handler and how to replace the old one.
 
-The new `ConnectionStringsSectionHandler2` works pretty much like it's non-numbered predecessor. The main difference is, when it
-enumerates through the list of connection strings in the section, it will ask builders to look for values that match
-"&lt;name&gt;:connectionString" and "&lt;name&gt;:providerName" in addition to just "&lt;name&gt;". When updating or inserting
-new `ConnectionStringSettings` items into the configuration collection, values that come from tagged keys will go to the
-appropriate attribute. Values that are found without a tagged key update the 'connectionString' property as they did before.
+The new `ConnectionStringsSectionHandler2` works pretty much like it's non-numbered predecessor. The main difference is, when it enumerates through the list of connection strings in the section, it will ask builders to look for values that match "&lt;name&gt;:connectionString" and "&lt;name&gt;:providerName" in addition to just "&lt;name&gt;". When updating or inserting new `ConnectionStringSettings` items into the configuration collection, values that come from tagged keys will go to the appropriate attribute. Values that are found without a tagged key update the 'connectionString' property as they did before.
 
 ```xml
     <connectionStrings configBuilders="StrictBuilder">
@@ -111,11 +79,6 @@ appropriate attribute. Values that are found without a tagged key update the 'co
     </connectionStrings>
 ```
 
-One thing to note is that the mechanism for associating a key/value lookup with a specific attribute of connection string entries
-is a simple post-fix to the key. This makes this feature incompatible with versioned keys in Azure Key Vault. Most other cases should
-just work as they did before, with a little extra magic cleanliness when you start using this feature.
+One thing to note is that the mechanism for associating a key/value lookup with a specific attribute of connection string entries is a simple post-fix to the key. This makes this feature incompatible with versioned keys in Azure Key Vault. Most other cases should just work as they did before, with a little extra magic cleanliness when you start using this feature.
 
-An example of this new behavior from `ConnectionStringsSectionHandler2` can be seen in the [SampleConsoleApp](https://github.com/aspnet/MicrosoftConfigurationBuilders/blob/1bdc2388f139c046e1c58bcc147c875d5c918785/samples/SampleConsoleApp/App.config#L37-L46).
-Or in the [test project](https://github.com/aspnet/MicrosoftConfigurationBuilders/blob/1bdc2388f139c046e1c58bcc147c875d5c918785/test/Microsoft.Configuration.ConfigurationBuilders.Test/ConnectionStringsSectionHandler2Tests.cs).
-The [SampleWebApp](https://github.com/aspnet/MicrosoftConfigurationBuilders/blob/1bdc2388f139c046e1c58bcc147c875d5c918785/samples/SampleWebApp/Web.config#L38-L41) does not use the new section handler, but it does include some notes about how
-it's resulting connection string collection would look different if it did.
+An example of this new behavior from `ConnectionStringsSectionHandler2` can be seen in the [SampleConsoleApp](https://github.com/aspnet/MicrosoftConfigurationBuilders/blob/1bdc2388f139c046e1c58bcc147c875d5c918785/samples/SampleConsoleApp/App.config#L37-L46). Or in the [test project](https://github.com/aspnet/MicrosoftConfigurationBuilders/blob/1bdc2388f139c046e1c58bcc147c875d5c918785/test/Microsoft.Configuration.ConfigurationBuilders.Test/ConnectionStringsSectionHandler2Tests.cs). The [SampleWebApp](https://github.com/aspnet/MicrosoftConfigurationBuilders/blob/1bdc2388f139c046e1c58bcc147c875d5c918785/samples/SampleWebApp/Web.config#L38-L41) does not use the new section handler, but it does include some notes about how it's resulting connection string collection would look different if it did.


### PR DESCRIPTION
Some markdown viewers are weird about the newlines in paragraphs. Not github, but other places. So formatting to keep paragraphs on one line and relying on word-wrap in my editor for sanity.

Also, adding a Table of Contents to the huge KeyValueConfigBuilders.md doc.