### PR TITLE
GetSecretClient should use the GetCredential() method that is overridable

### DIFF
--- a/src/AzureAppConfig/AzureAppConfigurationBuilder.cs
+++ b/src/AzureAppConfig/AzureAppConfigurationBuilder.cs
@@ -384,7 +384,7 @@ namespace Microsoft.Configuration.ConfigurationBuilders
 
         private SecretClient GetSecretClient(KeyVaultSecretIdentifier identifier)
         {
-            return _kvClientCache.GetOrAdd(identifier.VaultUri, uri => new SecretClient(identifier.VaultUri, new DefaultAzureCredential()));
+            return _kvClientCache.GetOrAdd(identifier.VaultUri, uri => new SecretClient(identifier.VaultUri, GetCredential()));
         }
     }
 }


### PR DESCRIPTION
GetSecretClient should use the GetCredential() method that is overridable.  Not using said method means that it might try using a different credential provider other than the one specified in the override and fail to pull secrets.