### PR TITLE
Add default values via 'tokenPattern' capture in Token mode

### DIFF
--- a/samples/SampleConsoleApp/App.config
+++ b/samples/SampleConsoleApp/App.config
@@ -18,6 +18,7 @@
       <add name="Json" mode="Greedy" jsonMode="Flat" jsonFile="${jsonFile}" type="Microsoft.Configuration.ConfigurationBuilders.SimpleJsonConfigBuilder, Microsoft.Configuration.ConfigurationBuilders.Json" />
       <add name="JsonCS" mode="Strict" jsonMode="Sectional" jsonFile="${jsonFile}"  type="Microsoft.Configuration.ConfigurationBuilders.SimpleJsonConfigBuilder, Microsoft.Configuration.ConfigurationBuilders.Json" />
       <add name="JsonExpand" mode="Token" jsonMode="Sectional" jsonFile="${jsonFile}"  type="SamplesLib.ExpandWrapper`1[[Microsoft.Configuration.ConfigurationBuilders.SimpleJsonConfigBuilder, Microsoft.Configuration.ConfigurationBuilders.Json]], SamplesLib" />
+      <add name="DefaultEnv" mode="Token" tokenPattern="\$\{(\w[\w-_$@#+,.~]*)(?:\:([^}]*))?\}" type="Microsoft.Configuration.ConfigurationBuilders.EnvironmentConfigBuilder, Microsoft.Configuration.ConfigurationBuilders.Environment" />
     </builders>
   </configBuilders>
 
@@ -29,9 +30,13 @@
     </handlers>
   </Microsoft.Configuration.ConfigurationBuilders.SectionHandlers>
 
-  <appSettings configBuilders="Env,KeyPerFile">
+  <appSettings configBuilders="Env,KeyPerFile,DefaultEnv">
     <add key="SampleItems" value="~/../../../SampleItems" />
     <add key="jsonFile" value="~/../../../SampleWebApp/App_Data/settings.json" />
+    <add key="TestingEnvDefaults1" value="${WINDIR:Should not see default.}" />
+    <add key="TestingEnvDefaults2" value="${ENV_VAR_DOES_NOT_EXIST:But a default value is here.}" />
+    <add key="TestingEnvDefaults3" value="${EMPTY_DEFAULT_VALUE:}" />
+    <add key="TestingEnvDefaults-DefaultValueNotRequiredWithThisPattern" value="${OS}" />
   </appSettings>
 
   <connectionStrings configBuilders="JsonCS">


### PR DESCRIPTION
Use second capture from tokenPattern to supply potential default values in Token mode.